### PR TITLE
feat: shadcn-grade unstyled demo, theme-aware avatars, pin-offset memo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,8 @@ coverage/
 # Playwright MCP scratch output (screenshots, snapshots) — never committed.
 .playwright-mcp/
 pg-*.png
+# Any scratch image dropped at the repo root (real assets live in site/ and
+# apps/*/public/) — agent/browser screenshots must never reach a commit.
+/*.png
+/*.jpeg
+/*.jpg

--- a/apps/playground/src/tailwind.css
+++ b/apps/playground/src/tailwind.css
@@ -65,3 +65,24 @@
   --color-accent-foreground: hsl(0 0% 9%);
   --color-ring: hsl(0 0% 63.9%);
 }
+
+/* UNLAYERED on purpose. Chakra's CSSReset (an emotion GLOBAL style injected by
+   the RTL section's ChakraProvider) applies `:where(*) { border-width: 0 }` to
+   the whole page and, being unlayered, beats every layered Tailwind utility.
+   These scoped restores are unlayered too, so the unstyled demo's borders
+   survive whatever kit is mounted alongside it. */
+[data-adapttable-part="root"] .border {
+  border-width: 1px;
+}
+[data-adapttable-part="root"] .border-b {
+  border-bottom-width: 1px;
+}
+[data-adapttable-part="root"] .border-t {
+  border-top-width: 1px;
+}
+[data-adapttable-part="root"] .border-s {
+  border-inline-start-width: 1px;
+}
+[data-adapttable-part="root"] .border-e {
+  border-inline-end-width: 1px;
+}

--- a/apps/showcase/src/adapters/ShadcnDemo.tsx
+++ b/apps/showcase/src/adapters/ShadcnDemo.tsx
@@ -18,6 +18,8 @@ const SHADCN: DataTableClassNames = {
   search:
     "w-full bg-transparent text-sm outline-none placeholder:text-muted-foreground",
   sortSelect: "h-9 rounded-md border border-input bg-background px-2 text-sm",
+  rowsPerPageSelect:
+    "h-8 rounded-md border border-input bg-background px-1.5 text-sm text-foreground",
   filtersButton:
     "inline-flex h-9 items-center gap-2 rounded-md border border-input bg-background px-3 text-sm font-medium hover:bg-accent hover:text-accent-foreground",
   filtersBackdrop: "fixed inset-0 z-40 bg-black/40 backdrop-blur-[1px]",
@@ -52,7 +54,7 @@ const SHADCN: DataTableClassNames = {
   footer:
     "flex items-center justify-between gap-2 border-t border-border p-3 text-sm text-muted-foreground",
   pageButton:
-    "h-8 min-w-8 rounded-md border border-input bg-background px-2 hover:bg-accent disabled:opacity-50",
+    "inline-grid h-8 min-w-8 place-items-center rounded-md border border-input bg-background px-2 text-foreground hover:bg-accent disabled:opacity-40",
   chips: "flex flex-wrap gap-2 px-3 pb-2",
   chip: "inline-flex items-center gap-1 rounded-full bg-muted px-2 py-1 text-xs text-muted-foreground",
   // ── Column popover ──────────────────────────────────────────────

--- a/apps/showcase/src/adapters/UnstyledDemo.tsx
+++ b/apps/showcase/src/adapters/UnstyledDemo.tsx
@@ -16,6 +16,8 @@ const TAILWIND: DataTableClassNames = {
   search:
     "w-full bg-transparent text-sm outline-none placeholder:text-gray-400",
   sortSelect: "h-9 rounded-md border border-gray-300 px-2 text-sm",
+  rowsPerPageSelect:
+    "h-8 rounded-md border border-indigo-200 bg-white px-1.5 text-sm dark:border-indigo-900/60 dark:bg-zinc-900",
   filtersButton:
     "inline-flex h-9 items-center gap-2 rounded-md border border-gray-300 px-3 text-sm font-medium text-gray-700 hover:bg-gray-50",
   filtersBackdrop: "fixed inset-0 z-40 bg-gray-900/30",

--- a/apps/showcase/src/adapters/UnstyledLike.tsx
+++ b/apps/showcase/src/adapters/UnstyledLike.tsx
@@ -1,5 +1,6 @@
 import { getDirection, getLabels } from "@adapttable/i18n";
 import { DataTable, type DataTableClassNames } from "@adapttable/unstyled";
+import type { CSSProperties } from "react";
 
 import {
   type AvatarCellProps,
@@ -23,6 +24,14 @@ import {
 } from "../data";
 import { type DataMode, DemoBody, type Density, type PageMode } from "../Demo";
 
+/** Inline style carrying the avatar's hue as a CSS custom property, so the
+ * Tailwind arbitrary values can theme it per light/dark. */
+type AvatarStyle = CSSProperties & { "--avatar-h": string };
+
+const avatarStyle = (name: string): AvatarStyle => ({
+  "--avatar-h": String(nameHue(name)),
+});
+
 const TAILWIND_STATUS = {
   green:
     "bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300",
@@ -35,11 +44,8 @@ const TAILWIND_STATUS = {
 const TAILWIND_CELLS: DemoCells = {
   Avatar: ({ name }: AvatarCellProps) => (
     <span
-      className="inline-grid h-9 w-9 place-items-center rounded-full text-xs font-bold"
-      style={{
-        background: `hsl(${nameHue(name)} 60% 88%)`,
-        color: `hsl(${nameHue(name)} 45% 35%)`,
-      }}
+      className="inline-grid h-9 w-9 place-items-center rounded-full text-xs font-bold [background:hsl(var(--avatar-h)_60%_88%)] [color:hsl(var(--avatar-h)_45%_30%)] dark:[background:hsl(var(--avatar-h)_45%_24%)] dark:[color:hsl(var(--avatar-h)_70%_78%)]"
+      style={avatarStyle(name)}
     >
       {initials(name)}
     </span>

--- a/apps/showcase/src/data.tsx
+++ b/apps/showcase/src/data.tsx
@@ -762,16 +762,19 @@ export function clearDemoFilters(source: TableSource<Person>): void {
  * adapters supply their own filter components, so this one is class-driven.
  */
 const FILTER = {
-  panel: "flex flex-col gap-3 text-sm text-gray-700 dark:text-gray-200",
-  group: "m-0 flex flex-col gap-1.5 border-0 p-0",
+  panel: "flex flex-col gap-4 text-sm text-foreground",
+  group: "m-0 flex flex-col gap-2 border-0 p-0",
   legend:
-    "p-0 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400",
-  chips: "flex flex-wrap gap-x-4 gap-y-2",
-  chip: "inline-flex items-center gap-1.5",
-  checkbox: "h-4 w-4 accent-indigo-600",
+    "p-0 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground",
+  chips: "flex flex-wrap gap-1.5",
+  // Toggle PILLS (the design's .at-filter chips): the real checkbox stays for
+  // a11y but renders invisibly; the label is the visual control and flips to
+  // a filled pill when its checkbox is checked.
+  chip: "inline-flex cursor-pointer select-none items-center rounded-full border border-input bg-background px-3 py-1 text-[13px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground has-[:checked]:border-primary has-[:checked]:bg-primary has-[:checked]:text-primary-foreground",
+  checkbox: "sr-only",
   grid: "grid grid-cols-2 gap-2",
   field:
-    "flex flex-col gap-1 [&>span]:text-xs [&>span]:text-gray-500 dark:[&>span]:text-gray-400 [&>input]:h-9 [&>input]:rounded-md [&>input]:border [&>input]:border-gray-300 [&>input]:bg-white [&>input]:px-2 [&>input]:outline-none dark:[&>input]:border-gray-600 dark:[&>input]:bg-gray-800 [&>select]:h-9 [&>select]:rounded-md [&>select]:border [&>select]:border-gray-300 [&>select]:bg-white [&>select]:px-2 [&>select]:outline-none dark:[&>select]:border-gray-600 dark:[&>select]:bg-gray-800",
+    "flex flex-col gap-1 [&>span]:text-xs [&>span]:font-medium [&>span]:text-muted-foreground [&>input]:h-9 [&>input]:rounded-md [&>input]:border [&>input]:border-input [&>input]:bg-background [&>input]:px-2.5 [&>input]:text-sm [&>input]:text-foreground [&>input]:outline-none focus-within:[&>input]:ring-2 focus-within:[&>input]:ring-ring [&>select]:h-9 [&>select]:rounded-md [&>select]:border [&>select]:border-input [&>select]:bg-background [&>select]:px-2 [&>select]:text-sm [&>select]:text-foreground [&>select]:outline-none",
 } as const;
 
 export function DemoFilters({

--- a/apps/showcase/src/tailwind.css
+++ b/apps/showcase/src/tailwind.css
@@ -36,6 +36,14 @@
      select arrows). Reset just buttons inside the unstyled table so the
      icon/ghost buttons render flat — utility classes still re-add any border
      or background where a slot asks for one. */
+  /* Native checkboxes pick up the theme's primary so they stay visible on
+     dark surfaces (preflight is skipped, so set it explicitly). */
+  [data-adapttable-part="root"] input[type="checkbox"] {
+    accent-color: var(--color-primary);
+    width: 1rem;
+    height: 1rem;
+  }
+
   [data-adapttable-part="root"] button {
     appearance: none;
     background: transparent;
@@ -83,4 +91,25 @@
   --color-accent: hsl(0 0% 20%);
   --color-accent-foreground: hsl(0 0% 98%);
   --color-ring: hsl(0 0% 45%);
+}
+
+/* UNLAYERED on purpose. Chakra's CSSReset (an emotion GLOBAL style injected by
+   the RTL section's ChakraProvider) applies `:where(*) { border-width: 0 }` to
+   the whole page and, being unlayered, beats every layered Tailwind utility.
+   These scoped restores are unlayered too, so the unstyled demo's borders
+   survive whatever kit is mounted alongside it. */
+[data-adapttable-part="root"] .border {
+  border-width: 1px;
+}
+[data-adapttable-part="root"] .border-b {
+  border-bottom-width: 1px;
+}
+[data-adapttable-part="root"] .border-t {
+  border-top-width: 1px;
+}
+[data-adapttable-part="root"] .border-s {
+  border-inline-start-width: 1px;
+}
+[data-adapttable-part="root"] .border-e {
+  border-inline-end-width: 1px;
 }

--- a/packages/adapter-unstyled/src/DataTable.test.tsx
+++ b/packages/adapter-unstyled/src/DataTable.test.tsx
@@ -62,6 +62,26 @@ beforeEach(() => vi.useFakeTimers({ shouldAdvanceTime: true }));
 afterEach(() => vi.useRealTimers());
 
 describe("<DataTable> (unstyled)", () => {
+  it("applies the rowsPerPageSelect class hook to both selects", () => {
+    const { container } = renderHarness({
+      override: { classNames: { rowsPerPageSelect: "my-rpp" } },
+    });
+    // Paged mode renders the footer select.
+    expect(
+      container.querySelector('[data-adapttable-part="footer"] select.my-rpp')
+    ).toBeInTheDocument();
+    const infinite = renderHarness({
+      mode: "infinite",
+      override: { classNames: { rowsPerPageSelect: "my-rpp" } },
+    });
+    // Infinite mode renders the toolbar select instead.
+    expect(
+      infinite.container.querySelector(
+        '[data-adapttable-part="toolbar"] select.my-rpp'
+      )
+    ).toBeInTheDocument();
+  });
+
   it("activates onRowClick from a row, but never from row actions", () => {
     const onRowClick = vi.fn();
     const onAction = vi.fn();

--- a/packages/adapter-unstyled/src/DataTable.tsx
+++ b/packages/adapter-unstyled/src/DataTable.tsx
@@ -313,6 +313,8 @@ export function DataTable<TRow>(props: Readonly<DataTableProps<TRow>>) {
             {labels.rowsPerPage}{" "}
             <select
               aria-label={labels.rowsPerPage}
+              data-adapttable-part="rows-per-page"
+              className={classNames.rowsPerPageSelect}
               value={source.limit}
               onChange={(e) => source.setLimit(Number(e.currentTarget.value))}
             >

--- a/packages/adapter-unstyled/src/components/chrome.tsx
+++ b/packages/adapter-unstyled/src/components/chrome.tsx
@@ -140,6 +140,8 @@ export function Footer({
         {labels.rowsPerPage}{" "}
         <select
           aria-label={labels.rowsPerPage}
+          data-adapttable-part="rows-per-page"
+          className={classNames.rowsPerPageSelect}
           value={source.limit}
           onChange={(e) => source.setLimit(Number(e.currentTarget.value))}
         >

--- a/packages/adapter-unstyled/src/types.ts
+++ b/packages/adapter-unstyled/src/types.ts
@@ -15,6 +15,8 @@ export interface DataTableClassNames {
   /** The leading magnifying-glass icon inside the search field. */
   searchIcon?: string;
   sortSelect?: string;
+  /** Rows-per-page `<select>` (toolbar in infinite mode, footer when paged). */
+  rowsPerPageSelect?: string;
   filtersButton?: string;
   /** The leading funnel icon inside the Filters button. */
   filtersIcon?: string;
@@ -38,7 +40,6 @@ export interface DataTableClassNames {
   columnMenuPanel?: string;
   columnMenuHeader?: string;
   columnMenuTitle?: string;
-  columnMenuHint?: string;
   columnMenuItem?: string;
   columnMenuGrip?: string;
   columnMenuLabel?: string;

--- a/packages/core/src/columns/useColumnLayout.ts
+++ b/packages/core/src/columns/useColumnLayout.ts
@@ -270,32 +270,38 @@ export function useColumnLayout<TRow>({
 
   const reset = useCallback(() => commit(EMPTY_COLUMN_LAYOUT), [commit]);
 
-  const pinOffset = useCallback(
-    (key: string) => {
-      const side = state.pinned[key];
-      if (!side) return undefined;
-      const resolveWidth = (k: string): number => {
-        if (typeof state.widths[k] === "number") return state.widths[k];
-        const declared = columns.find((c) => c.key === k)?.width;
-        // Only pixel widths can be summed into a sticky inset; relative units
-        // have no px value here, so fall back to a sane default instead.
-        return parsePxWidth(declared) ?? FALLBACK_PIN_WIDTH;
-      };
+  // Precompute every pinned column's inset once per layout change — adapters
+  // call `pinOffset` per cell per render, so a lookup beats re-walking the
+  // pinned set each time on wide tables.
+  const pinInsets = useMemo(() => {
+    const resolveWidth = (column: ColumnDef<TRow>): number => {
+      const override = state.widths[column.key];
+      if (typeof override === "number") return override;
+      // Only pixel widths can be summed into a sticky inset; relative units
+      // have no px value here, so fall back to a sane default instead.
+      return parsePxWidth(column.width) ?? FALLBACK_PIN_WIDTH;
+    };
+    const insets = new Map<string, { side: "left" | "right"; inset: number }>();
+    for (const side of ["left", "right"] as const) {
+      // Only VISIBLE pinned columns have a rendered cell to stick — a hidden
+      // pinned key stays out of the map and reads back as unpinned.
       const samePinned = visibleColumns.filter(
         (c) => state.pinned[c.key] === side
       );
-      const idx = samePinned.findIndex((c) => c.key === key);
-      // A pinned key that isn't visible (hidden, or filtered by the device
-      // layout) has no rendered cell to stick — report it unpinned instead of
-      // computing a garbage inset from index -1.
-      if (idx === -1) return undefined;
-      // Left: sum widths before this column; right: sum widths after it.
-      const preceding =
-        side === "left" ? samePinned.slice(0, idx) : samePinned.slice(idx + 1);
-      const inset = preceding.reduce((sum, c) => sum + resolveWidth(c.key), 0);
-      return { side, inset };
-    },
-    [columns, state.pinned, state.widths, visibleColumns]
+      // Left: sum widths before each column; right: sum widths after it.
+      const ordered = side === "left" ? samePinned : [...samePinned].reverse();
+      let inset = 0;
+      for (const column of ordered) {
+        insets.set(column.key, { side, inset });
+        inset += resolveWidth(column);
+      }
+    }
+    return insets;
+  }, [state.pinned, state.widths, visibleColumns]);
+
+  const pinOffset = useCallback(
+    (key: string) => pinInsets.get(key),
+    [pinInsets]
   );
 
   return {


### PR DESCRIPTION
The unstyled/shadcn demo shipped its worst first impression — and the root cause was a real bug, not taste: Chakra's CSSReset (an emotion GLOBAL style injected by the RTL section's ChakraProvider) zeroes border-width on the whole page UNLAYERED, silently defeating every layered Tailwind utility in the demo. Scoped unlayered restores bring back all .border* utilities inside the table (showcase + playground).

Demo polish on top of the fix:
- filter form redesigned to shadcn pill toggles (sr-only checkboxes for a11y, has-[:checked] filled state, tokenized inputs/selects)
- avatars carry their hue as a CSS variable so dark mode renders deep-toned chips instead of glaring pastels; checkboxes pick up accent-color
- footer rows-per-page select and pager buttons styled via the adapter's new `rowsPerPageSelect` classNames hook (replaces the dead, never-rendered `columnMenuHint` key)

Core: pinOffset now reads from a memoized inset map (one walk per layout change instead of one per cell per render on wide pinned tables).

Process: repo-root images are gitignored (anchored /*.png — nested assets in site/ and apps/*/public/ unaffected) so browser screenshots can never reach a commit.

<!-- Thanks for contributing to AdaptTable! -->

## What does this PR do?

<!-- A short summary of the change and the motivation. Link any related issue: "Closes #123". -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Docs / chore / refactor (no runtime behaviour change)

## Affected packages

- [ ] `@adapttable/core`
- [ ] `@adapttable/mantine`
- [ ] `@adapttable/mui`
- [ ] `@adapttable/chakra`
- [ ] `@adapttable/unstyled`
- [ ] `@adapttable/i18n`
- [ ] `@adapttable/cli`

## Checklist

- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` all pass.
- [ ] Added or updated tests for the change (coverage stays ~100%).
- [ ] Behaviour is consistent across the affected adapters.
- [ ] Added a changeset (`pnpm changeset`) describing the change for the release notes.
- [ ] Updated the docs / README if the public API or behaviour changed.
