### PR TITLE
fix(docs): splash landing page at the site root

### DIFF
--- a/apps/docs/sync-docs.mjs
+++ b/apps/docs/sync-docs.mjs
@@ -32,4 +32,49 @@ for (const file of readdirSync(source)) {
     `---\ntitle: ${JSON.stringify(title)}\n---\n\n${body}`
   );
 }
+// The site root: a splash landing the repo docs don't carry (they're
+// guide pages). Emitted here so the generated content dir stays the only
+// owner of src/content/docs.
+const INDEX = `---
+title: AdaptTable
+description: One headless React data-table engine with batteries-included adapters for Mantine, MUI, Chakra UI, Ant Design, and Tailwind.
+template: splash
+hero:
+  tagline: One headless engine. Every UI kit. URL-synced state, real filters, RTL, virtualization — rendered natively by your design system.
+  actions:
+    - text: Get started
+      link: /adapttable/getting-started/
+      icon: right-arrow
+      variant: primary
+    - text: Live demo
+      link: /adapttable/demo/
+      icon: rocket
+    - text: GitHub
+      link: https://github.com/orwa-mahmoud/adapttable
+      icon: github
+      variant: minimal
+---
+
+import { Card, CardGrid } from "@astrojs/starlight/components";
+
+<CardGrid stagger>
+  <Card title="Declarative columns & filters" icon="setting">
+    \`{ key: "team", filter: "multiSelect" }\` — the widget, URL params,
+    chips and predicate all derive from one definition.
+  </Card>
+  <Card title="Your design system" icon="puzzle">
+    The same table renders natively in Mantine, MUI, Chakra UI, Ant
+    Design, or your own Tailwind classes — pick an adapter, keep the API.
+  </Card>
+  <Card title="URL-synced everything" icon="external">
+    Search, sort, filters, pagination, column layout and saved views all
+    live in shareable URLs.
+  </Card>
+  <Card title="50,000 rows, no flinching" icon="rocket">
+    Opt-in virtualization windows the DOM against the page or any scroll
+    box — try it in the live demo.
+  </Card>
+</CardGrid>
+`;
+writeFileSync(join(target, "index.mdx"), INDEX);
 console.log("docs synced into Starlight");


### PR DESCRIPTION
The deployed docs site 404d at its root - the content collection only carried the synced guide pages, nothing served /adapttable/ itself. sync-docs.mjs now also emits an index.mdx splash (hero with Get started / Live demo / GitHub actions plus four feature cards), keeping the generated content dir the sole owner of src/content/docs.

Verified on the built dist: the root renders the hero and links resolve to getting-started/, demo/, and the repo.

<!-- Thanks for contributing to AdaptTable! -->

## What does this PR do?

<!-- A short summary of the change and the motivation. Link any related issue: "Closes #123". -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Docs / chore / refactor (no runtime behaviour change)

## Affected packages

- [ ] `@adapttable/core`
- [ ] `@adapttable/mantine`
- [ ] `@adapttable/mui`
- [ ] `@adapttable/chakra`
- [ ] `@adapttable/unstyled`
- [ ] `@adapttable/i18n`
- [ ] `@adapttable/cli`

## Checklist

- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` all pass.
- [ ] Added or updated tests for the change (coverage stays ~100%).
- [ ] Behaviour is consistent across the affected adapters.
- [ ] Added a changeset (`pnpm changeset`) describing the change for the release notes.
- [ ] Updated the docs / README if the public API or behaviour changed.
