### PR TITLE
fix: compact range rows, constant operator width, CI turbo cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Turborepo's task cache, persisted across CI runs: tasks whose
+      # inputs (and dependencies' outputs) are unchanged restore instantly
+      # instead of re-linting/re-testing untouched packages. Changing core
+      # still re-verifies every adapter — the hash includes dependency
+      # outputs, so "new code breaks an old test" is always caught.
+      - name: Restore Turborepo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-
+
       - name: Format check
         run: pnpm format:check
 

--- a/packages/adapter-antd/src/components/AutoFilterForm.tsx
+++ b/packages/adapter-antd/src/components/AutoFilterForm.tsx
@@ -125,7 +125,7 @@ function RangeField({
       return (
         <InputNumber
           size="small"
-          style={{ width: "100%" }}
+          style={{ flex: "1 1 6rem", minWidth: "6rem", width: "auto" }}
           aria-label={`${label} ${suffix}`}
           placeholder={suffix}
           value={value === "" ? null : Number(value)}
@@ -135,6 +135,7 @@ function RangeField({
     }
     return (
       <Input
+        style={{ flex: "1 1 8.5rem", minWidth: "8.5rem" }}
         size="small"
         type="date"
         aria-label={`${label} ${suffix}`}
@@ -145,10 +146,13 @@ function RangeField({
     );
   };
   return (
-    <Flex vertical gap={8} style={{ position: "relative" }}>
+    // Operator and value(s) share a row when they fit and wrap when they
+    // don't (date inputs have a wide native minimum).
+    <Flex gap={8} wrap style={{ position: "relative" }}>
       <Select<RangeOp | undefined>
         size="small"
         allowClear
+        style={{ flex: "0 0 8.5rem", width: "8.5rem" }}
         aria-label={`${label} ${labels.operator}`}
         placeholder={labels.operator}
         value={op}
@@ -165,10 +169,10 @@ function RangeField({
         op !== "between" &&
         input(labels.value, single, (next) => apply(op, next, ""))}
       {op === "between" && (
-        <Flex gap={8}>
+        <>
           {input(labels.from, low, (next) => apply("between", next, high))}
           {input(labels.to, high, (next) => apply("between", low, next))}
-        </Flex>
+        </>
       )}
     </Flex>
   );

--- a/packages/adapter-chakra/src/components/AutoFilterForm.tsx
+++ b/packages/adapter-chakra/src/components/AutoFilterForm.tsx
@@ -100,12 +100,18 @@ function RangeField<TRow>({
       <FormLabel fontSize="sm" mb={1}>
         {label}
       </FormLabel>
-      <Stack spacing={2}>
+      {/* Operator and value(s) share ONE row — it reads like a sentence:
+          "At least [5]". */}
+      <HStack spacing={2} align="flex-start" flexWrap="wrap" rowGap={2}>
         {/* Chakra renders `placeholder` as the empty first option, so the
             operator placeholder doubles as the "no comparison" clear choice. */}
         <Select
           size="sm"
-          rootProps={selectIconRootProps(dir)}
+          rootProps={{
+            ...selectIconRootProps(dir),
+            flex: "0 0 8.5rem",
+            w: "8.5rem",
+          }}
           placeholder={labels.operator}
           value={op ?? ""}
           onChange={(e) => {
@@ -121,10 +127,12 @@ function RangeField<TRow>({
           ))}
         </Select>
         {op === "between" ? (
-          <HStack spacing={2}>
+          <>
             <Input
               id={`${id}-a`}
               size="sm"
+              flex="1 1 7rem"
+              minW="7rem"
               type={inputType}
               aria-label={labels.from}
               placeholder={labels.from}
@@ -134,18 +142,22 @@ function RangeField<TRow>({
             <Input
               id={`${id}-b`}
               size="sm"
+              flex="1 1 7rem"
+              minW="7rem"
               type={inputType}
               aria-label={labels.to}
               placeholder={labels.to}
               value={b}
               onChange={(e) => write(op, a, e.target.value)}
             />
-          </HStack>
+          </>
         ) : (
           op && (
             <Input
               id={`${id}-a`}
               size="sm"
+              flex="1 1 7rem"
+              minW="7rem"
               type={inputType}
               aria-label={labels.value}
               placeholder={labels.value}
@@ -154,7 +166,7 @@ function RangeField<TRow>({
             />
           )
         )}
-      </Stack>
+      </HStack>
     </FormControl>
   );
 }

--- a/packages/adapter-chakra/src/components/tables.tsx
+++ b/packages/adapter-chakra/src/components/tables.tsx
@@ -901,7 +901,9 @@ export function MobileCards<TRow>({
                   <Text fontSize="xs" {...subtleText} textTransform="uppercase">
                     {mobileLabel(column)}
                   </Text>
-                  <Text fontSize="sm">
+                  {/* Cells are arbitrary ReactNode (often block elements) —
+                      a <p> wrapper would be invalid HTML. */}
+                  <Text as="div" fontSize="sm">
                     {column.Cell ? (
                       <column.Cell row={row} rowIndex={index} />
                     ) : (

--- a/packages/adapter-mantine/src/components/AutoFilterForm.tsx
+++ b/packages/adapter-mantine/src/components/AutoFilterForm.tsx
@@ -112,6 +112,7 @@ function RangeField<TRow>({
       <NumberInput
         size="sm"
         hideControls
+        style={{ flex: "1 1 6rem", minWidth: "6rem" }}
         aria-label={`${label} ${text}`}
         placeholder={text}
         value={value}
@@ -121,6 +122,7 @@ function RangeField<TRow>({
       <TextInput
         type="date"
         size="sm"
+        style={{ flex: "1 1 8.5rem", minWidth: "8.5rem" }}
         aria-label={`${label} ${text}`}
         placeholder={text}
         value={value}
@@ -131,10 +133,10 @@ function RangeField<TRow>({
   let values: ReactNode = null;
   if (op === "between") {
     values = (
-      <Group gap="xs" grow wrap="nowrap">
+      <>
         {valueInput(labels.from, low, (next) => write("between", next, high))}
         {valueInput(labels.to, high, (next) => write("between", low, next))}
-      </Group>
+      </>
     );
   } else if (op) {
     values = valueInput(labels.value, single, (next) => write(op, next, ""));
@@ -143,17 +145,23 @@ function RangeField<TRow>({
   return (
     <Stack gap={4}>
       <Input.Label size="sm">{label}</Input.Label>
-      <Select
-        size="sm"
-        clearable
-        aria-label={`${label} ${labels.operator}`}
-        placeholder={labels.operator}
-        data={data}
-        value={op}
-        onChange={handleOp}
-        comboboxProps={{ withinPortal: false }}
-      />
-      {values}
+      {/* Operator and value(s) share a row when they fit — "At least [5]" —
+          and wrap when they don't (date inputs have a wide native minimum,
+          so "Between" two dates takes a second row in narrow drawers). */}
+      <Group gap="xs" align="flex-start">
+        <Select
+          size="sm"
+          clearable
+          style={{ flex: "0 0 8.5rem", width: "8.5rem" }}
+          aria-label={`${label} ${labels.operator}`}
+          placeholder={labels.operator}
+          data={data}
+          value={op}
+          onChange={handleOp}
+          comboboxProps={{ withinPortal: false }}
+        />
+        {values}
+      </Group>
     </Stack>
   );
 }

--- a/packages/adapter-mantine/src/components/MobileCards.tsx
+++ b/packages/adapter-mantine/src/components/MobileCards.tsx
@@ -136,7 +136,9 @@ export function MobileCards<TRow>({
                   <Text fz="xs" c="dimmed" tt="uppercase" fw={500}>
                     {mobileLabel(column)}
                   </Text>
-                  <Text fz="sm">
+                  {/* Cells are arbitrary ReactNode (often block elements) —
+                      a <p> wrapper would be invalid HTML. */}
+                  <Text component="div" fz="sm">
                     {column.Cell ? (
                       <column.Cell row={row} rowIndex={index} />
                     ) : (
@@ -213,7 +215,7 @@ export function MobileCards<TRow>({
                   <Text fz="xs" c="dimmed" tt="uppercase" fw={500}>
                     {mobileLabel(column)}
                   </Text>
-                  <Text fz="sm" fw={600}>
+                  <Text component="div" fz="sm" fw={600}>
                     {summaryCells[column.key]}
                   </Text>
                 </div>

--- a/packages/adapter-mui/src/components/AutoFilterForm.tsx
+++ b/packages/adapter-mui/src/components/AutoFilterForm.tsx
@@ -179,12 +179,12 @@ function RangeFilter<TRow>({
   ) => (
     <TextField
       size="small"
+      sx={{ flex: "1 1 7rem", minWidth: "7rem" }}
       type={type === "dateRange" ? "date" : "number"}
       label={label}
       value={value}
       onChange={(e) => write(e.target.value)}
       slotProps={{ inputLabel: { shrink: true } }}
-      sx={{ flex: 1 }}
     />
   );
   let bounds: ReactNode = null;
@@ -203,7 +203,7 @@ function RangeFilter<TRow>({
       <FormLabel component="legend" sx={{ mb: 0.75 }}>
         {filterLabel(def)}
       </FormLabel>
-      <Stack direction="row" spacing={1}>
+      <Stack direction="row" spacing={1} useFlexGap flexWrap="wrap">
         <TextField
           select
           size="small"
@@ -214,7 +214,7 @@ function RangeFilter<TRow>({
             select: { native: true },
             inputLabel: { shrink: true },
           }}
-          sx={{ flex: 1 }}
+          sx={{ flex: "0 0 8.5rem", width: "8.5rem" }}
         >
           <option value="" />
           {RANGE_OPS.map((candidate) => (

--- a/packages/adapter-mui/src/components/tables.tsx
+++ b/packages/adapter-mui/src/components/tables.tsx
@@ -869,7 +869,9 @@ export function MobileCards<TRow>({
                   >
                     {mobileLabel(column)}
                   </Typography>
-                  <Typography variant="body2">
+                  {/* Cells are arbitrary ReactNode (often block elements) —
+                      a <p> wrapper would be invalid HTML. */}
+                  <Typography component="div" variant="body2">
                     {column.Cell ? (
                       <column.Cell row={row} rowIndex={index} />
                     ) : (
@@ -914,7 +916,9 @@ export function MobileCards<TRow>({
                   >
                     {mobileLabel(column)}
                   </Typography>
-                  <Typography variant="body2">{value}</Typography>
+                  <Typography component="div" variant="body2">
+                    {value}
+                  </Typography>
                 </Box>
               );
             })}

--- a/packages/adapter-unstyled/src/components/AutoFilterForm.tsx
+++ b/packages/adapter-unstyled/src/components/AutoFilterForm.tsx
@@ -230,6 +230,7 @@ function RangeValueInput({
   return (
     <input
       type={type}
+      style={{ flex: "1 1 7rem", minWidth: "7rem" }}
       placeholder={label}
       aria-label={label}
       data-adapttable-part="filter-input"
@@ -278,9 +279,12 @@ function RangeField<TRow>({
   const opLabelKeys = RANGE_OP_LABEL_KEYS[inputType];
   return (
     <GroupField caption={filterLabel(def)} classNames={classNames}>
-      {/* Structural layout only (like the toolbar): parts sit side by side. */}
-      <div style={{ display: "flex", gap: 8 }}>
+      {/* Structural layout only (like the toolbar): the operator keeps a
+          constant width; values fill the rest and wrap when they don't fit
+          (date inputs have a wide native minimum). */}
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8 }}>
         <select
+          style={{ flex: "0 0 8.5rem", width: "8.5rem" }}
           aria-label={labels.operator}
           data-adapttable-part="filter-operator"
           className={classNames.filterOperator}


### PR DESCRIPTION
Field review of the operator-first widgets across every kit:

- The operator and its value(s) now share a row that reads like a sentence ("At least [5]") instead of stacking full-width controls. The operator keeps a CONSTANT width (flex: 0 0 8.5rem) - it no longer fills the row while empty and shrinks on selection - and the value inputs take the remaining space, wrapping to the next row when they do not fit (date inputs have a wide native minimum, so date "Between" wraps in narrow popovers/drawers instead of crushing the select or overflowing the container).
- Mobile-card cell values in mantine/mui/chakra rendered arbitrary ReactNode inside <p> wrappers - block-element cells (like the scale demo person cell) produced invalid HTML and React DOM-nesting warnings. The value and summary wrappers are <div>-rendered text now; plain-string label wrappers stay as they were. antd (span) and unstyled (div) were already valid.
- ci.yml persists the Turborepo cache (.turbo) across runs via actions/cache: tasks whose inputs and dependency outputs are unchanged restore instantly instead of re-linting/re-testing untouched packages, while a core change still re-verifies every adapter (the hash includes dependency outputs).

Browser-verified at 1440px and 390px: constant operator width before/ after selection, zero overflow, date Between wrapping to two rows, mobile cards clean of DOM-nesting errors. Coverage: 100% everywhere (167/135/145/155/171).

<!-- Thanks for contributing to AdaptTable! -->

## What does this PR do?

<!-- A short summary of the change and the motivation. Link any related issue: "Closes #123". -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Docs / chore / refactor (no runtime behaviour change)

## Affected packages

- [ ] `@adapttable/core`
- [ ] `@adapttable/mantine`
- [ ] `@adapttable/mui`
- [ ] `@adapttable/chakra`
- [ ] `@adapttable/unstyled`
- [ ] `@adapttable/i18n`
- [ ] `@adapttable/cli`

## Checklist

- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` all pass.
- [ ] Added or updated tests for the change (coverage stays ~100%).
- [ ] Behaviour is consistent across the affected adapters.
- [ ] Added a changeset (`pnpm changeset`) describing the change for the release notes.
- [ ] Updated the docs / README if the public API or behaviour changed.
