### PR TITLE
fix: toolbars wrap on narrow screens instead of clipping controls

### DIFF
--- a/packages/adapter-antd/src/components/chrome.tsx
+++ b/packages/adapter-antd/src/components/chrome.tsx
@@ -86,7 +86,7 @@ export function Toolbar<TRow>({
   );
 
   return (
-    <Flex gap="small" wrap={false} align="center" justify="space-between">
+    <Flex gap="small" wrap align="center" justify="space-between">
       {!hideSearch && (
         <Input
           type="search"
@@ -103,7 +103,7 @@ export function Toolbar<TRow>({
           }
         />
       )}
-      <Flex gap="small" wrap={false} align="center">
+      <Flex gap="small" wrap align="center">
         {isRefreshing && <Spin size="small" aria-label={labels.loading} />}
         {sortOptions && sortOptions.length > 0 && (
           <Select

--- a/packages/adapter-chakra/src/components/chrome.tsx
+++ b/packages/adapter-chakra/src/components/chrome.tsx
@@ -173,7 +173,8 @@ export function Toolbar<TRow>({
   return (
     <HStack
       spacing={2}
-      flexWrap="nowrap"
+      flexWrap="wrap"
+      rowGap={2}
       justify="space-between"
       align="center"
       className={className}
@@ -196,7 +197,7 @@ export function Toolbar<TRow>({
           />
         </InputGroup>
       )}
-      <HStack spacing={2} flexWrap="nowrap" align="center">
+      <HStack spacing={2} flexWrap="wrap" rowGap={2} align="center">
         {sortOptions && sortOptions.length > 0 && (
           <Select
             size="sm"

--- a/packages/adapter-mantine/src/components/Toolbar.tsx
+++ b/packages/adapter-mantine/src/components/Toolbar.tsx
@@ -74,7 +74,6 @@ export function Toolbar<TRow>({
   return (
     <Group
       gap="sm"
-      wrap="nowrap"
       justify="space-between"
       align="center"
       className={className}
@@ -87,7 +86,7 @@ export function Toolbar<TRow>({
           style={{ flex: 1, minWidth: 160, maxWidth: 360 }}
         />
       )}
-      <Group gap="xs" wrap="nowrap" align="center">
+      <Group gap="xs" align="center">
         {sortOptions && sortOptions.length > 0 && (
           <Select
             aria-label={labels.sortBy}

--- a/packages/adapter-mui/src/components/chrome.tsx
+++ b/packages/adapter-mui/src/components/chrome.tsx
@@ -145,10 +145,10 @@ export function Toolbar<TRow>({
     <Stack
       direction="row"
       spacing={1}
-      flexWrap="nowrap"
+      flexWrap="wrap"
+      useFlexGap
       alignItems="center"
       justifyContent="space-between"
-      useFlexGap
     >
       {!hideSearch && (
         <TextField
@@ -177,7 +177,7 @@ export function Toolbar<TRow>({
         direction="row"
         spacing={1}
         alignItems="center"
-        flexWrap="nowrap"
+        flexWrap="wrap"
         useFlexGap
       >
         {sortOptions && sortOptions.length > 0 && (

--- a/packages/adapter-unstyled/src/DataTable.tsx
+++ b/packages/adapter-unstyled/src/DataTable.tsx
@@ -288,7 +288,12 @@ export function DataTable<TRow>(props: Readonly<DataTableProps<TRow>>) {
       <div
         data-adapttable-part="toolbar"
         className={classNames.toolbar}
-        style={{ display: "flex", flexWrap: "nowrap", alignItems: "center" }}
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          alignItems: "center",
+          rowGap: 8,
+        }}
       >
         {!hideSearch && (
           <span


### PR DESCRIPTION
Every kit pinned its toolbar to one row (outer AND inner flex both nowrap), so at phone widths the Filters button got cut at the card edge and the rows-per-page select ran past it. Both levels now wrap: the search takes its own row when space is short (it keeps its usable minimum), and the sort / filters / columns / rows-per-page cluster flows onto following rows.

Browser-verified at 390px across all six demo variants: zero clipped controls, zero toolbar or page overflow, Filters fully visible. Coverage stays 100% (167/135/145/155/171).

<!-- Thanks for contributing to AdaptTable! -->

## What does this PR do?

<!-- A short summary of the change and the motivation. Link any related issue: "Closes #123". -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Docs / chore / refactor (no runtime behaviour change)

## Affected packages

- [ ] `@adapttable/core`
- [ ] `@adapttable/mantine`
- [ ] `@adapttable/mui`
- [ ] `@adapttable/chakra`
- [ ] `@adapttable/unstyled`
- [ ] `@adapttable/i18n`
- [ ] `@adapttable/cli`

## Checklist

- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` all pass.
- [ ] Added or updated tests for the change (coverage stays ~100%).
- [ ] Behaviour is consistent across the affected adapters.
- [ ] Added a changeset (`pnpm changeset`) describing the change for the release notes.
- [ ] Updated the docs / README if the public API or behaviour changed.
