### PR TITLE
fix(docs): serve Getting started AT the root - no redirect

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -5,9 +5,6 @@ import { defineConfig } from "astro/config";
 export default defineConfig({
   site: "https://orwa-mahmoud.github.io",
   base: "/adapttable",
-  // The root IS the docs: land straight on Getting started instead of a
-  // separate marketing page (the showcase at /demo plays that role).
-  redirects: { "/": "/adapttable/getting-started/" },
   integrations: [
     starlight({
       title: "AdaptTable",
@@ -26,7 +23,8 @@ export default defineConfig({
           link: "/demo/",
           attrs: { target: "_blank" },
         },
-        { label: "Getting started", slug: "getting-started" },
+        // Getting started serves AT the root (sync-docs gives it slug "").
+        { label: "Getting started", link: "/" },
         { label: "Customization", slug: "customization" },
         { label: "URL state", slug: "url-state" },
         { label: "API reference", slug: "api" },

--- a/apps/docs/sync-docs.mjs
+++ b/apps/docs/sync-docs.mjs
@@ -25,10 +25,16 @@ for (const file of readdirSync(source)) {
   const raw = readFileSync(join(source, file), "utf8");
   // Drop the H1 (Starlight renders the frontmatter title) and de-link
   // repo-relative paths that have no meaning on the site.
-  const body = raw.replace(/^# .*\n/, "");
+  const body = raw
+    .replace(/^# .*\n/, "")
+    // Getting started lives at the site root now.
+    .replace(/\(\.\/getting-started\.md\)/g, "(/adapttable/)");
   const title = TITLES[file] ?? file.replace(/\.md$/, "");
+  // Getting started IS the site root — its content serves at "/" directly
+  // (no landing page, no redirect): index.md is how Starlight roots a page.
+  const outName = file === "getting-started.md" ? "index.md" : file;
   writeFileSync(
-    join(target, file),
+    join(target, outName),
     `---\ntitle: ${JSON.stringify(title)}\n---\n\n${body}`
   );
 }

--- a/apps/showcase/src/sections.tsx
+++ b/apps/showcase/src/sections.tsx
@@ -262,7 +262,7 @@ export function FeatureGrid() {
 
 const FOOT_LINKS = [
   { label: "Docs", href: DOCS_URL },
-  { label: "Get started", href: `${DOCS_URL}getting-started/` },
+  { label: "Get started", href: DOCS_URL },
   { label: "API", href: `${DOCS_URL}api/` },
   { label: "Compare", href: `${DOCS_URL}comparison/` },
   { label: "GitHub", href: REPO_URL },
@@ -290,7 +290,7 @@ export function GetStarted() {
           <div className="getstarted__btns">
             <a
               className="gs-btn gs-btn--primary"
-              href={`${DOCS_URL}getting-started/`}
+              href={DOCS_URL}
               target="_blank"
               rel="noreferrer"
             >

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -110,7 +110,7 @@ npx @adapttable/cli init   # detects your UI kit and scaffolds a table
 ```
 
 Or install an adapter directly, e.g. `pnpm add @adapttable/mantine`. See
-[getting-started.md](./getting-started.md).
+[the Getting started guide](./getting-started.md).
 
 ## When might another library fit better?
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1308,7 +1308,7 @@ npx @adapttable/cli init   # detects your UI kit and scaffolds a table
 ```
 
 Or install an adapter directly, e.g. `pnpm add @adapttable/mantine`. See
-[getting-started.md](./getting-started.md).
+[the Getting started guide](./getting-started.md).
 
 ## When might another library fit better?
 


### PR DESCRIPTION
The meta-refresh redirect flashed an intermediate page on the first click into the docs. Gone: sync-docs now emits getting-started.md as index.md, so its content IS the site root; the sidebar links the entry to "/", the showcase deep-links point at the root, and the FAQ cross-link follows.

Verified on the built dist: the root serves the Getting started page (title, h1, full sidebar), no meta refresh anywhere, no separate /getting-started/ path.

<!-- Thanks for contributing to AdaptTable! -->

## What does this PR do?

<!-- A short summary of the change and the motivation. Link any related issue: "Closes #123". -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Docs / chore / refactor (no runtime behaviour change)

## Affected packages

- [ ] `@adapttable/core`
- [ ] `@adapttable/mantine`
- [ ] `@adapttable/mui`
- [ ] `@adapttable/chakra`
- [ ] `@adapttable/unstyled`
- [ ] `@adapttable/i18n`
- [ ] `@adapttable/cli`

## Checklist

- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` all pass.
- [ ] Added or updated tests for the change (coverage stays ~100%).
- [ ] Behaviour is consistent across the affected adapters.
- [ ] Added a changeset (`pnpm changeset`) describing the change for the release notes.
- [ ] Updated the docs / README if the public API or behaviour changed.
