### PR TITLE
docs: refresh the v0.1.0 release notes to the shipped feature set

### DIFF
--- a/.changeset/initial-release.md
+++ b/.changeset/initial-release.md
@@ -10,21 +10,29 @@
 ---
 
 Initial public release of AdaptTable — a headless, UI-agnostic React data
-table.
+table: one API, rendered natively by your design system.
 
-- `@adapttable/core`: headless engine — the `TableSource` contract,
-  `useFrontendData` / `useBackendData`, URL-synced state with an injectable
-  adapter, `useDataTable` prop-getters, selection, filter chips, sorting,
-  pagination, true infinite scroll (`useInfiniteScroll` — an
-  IntersectionObserver sentinel that auto-loads the next page), and
-  dark-mode resolution.
-- Batteries-included adapters for **Mantine**, **MUI**, **Chakra**, **Ant
-  Design** (on antd's high-level `<Table>`), and **Tailwind/shadcn**
-  (`@adapttable/unstyled`).
-- `@adapttable/i18n`: English + Arabic label presets and RTL helpers.
-- `@adapttable/cli`: `npx @adapttable/cli init` to detect your kit and
-  scaffold.
+- `@adapttable/core`: the headless engine — declarative `columns` (bare
+  keys, dot-paths, auto headers) and `filters` (one definition drives the
+  widget, URL params, chips, and predicate, with `"auto"` and async option
+  sources), three data tiers (in-memory, server via one consolidated
+  `onQueryChange(query, { signal })`, or a full custom `TableSource`),
+  URL-synced state with an injectable adapter (`urlSync={false}` for
+  in-memory), multi-sort, summary rows, header groups, row expansion,
+  saved views, select-all-N-matching, keyboard row navigation, and opt-in
+  row/card virtualization that tracks the page or any `maxHeight` scroll
+  box — 50,000 rows stay a handful of DOM nodes.
+- Batteries-included adapters for **Mantine**, **MUI**, **Chakra UI**,
+  **Ant Design**, and **Tailwind/shadcn** (`@adapttable/unstyled`): native
+  filter forms with operator-first number/date ranges, column management
+  (hide / reorder / pin / resize — the row-actions column included), a
+  built-in saved-views menu, mobile card layouts, and memoized rows.
+- `@adapttable/i18n`: label presets for ten locales (en, ar, de, es, fr,
+  he, it, ja, pt, zh) with RTL helpers — headers, cells, sorting and
+  filtering can all follow per-locale data paths.
+- `@adapttable/cli`: `npx @adapttable/cli init` detects your kit and
+  scaffolds a working table.
 
-Highlights: one API for client and server data, shareable URL state,
-infinite scroll **and** paging (auto by device), first-class RTL, seamless
-dark mode, and a full headless escape hatch.
+Highlights: shareable URL state, paging and true infinite scroll (auto by
+device), first-class RTL, seamless dark mode, 100% test coverage, and a
+full headless escape hatch at every layer.


### PR DESCRIPTION
The queued changeset becomes the permanent CHANGELOG; it predated the declarative API, the operator-first filters, element virtualization, saved views, the managed actions column, and the growth from two label presets to ten locales.

<!-- Thanks for contributing to AdaptTable! -->

## What does this PR do?

<!-- A short summary of the change and the motivation. Link any related issue: "Closes #123". -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Docs / chore / refactor (no runtime behaviour change)

## Affected packages

- [ ] `@adapttable/core`
- [ ] `@adapttable/mantine`
- [ ] `@adapttable/mui`
- [ ] `@adapttable/chakra`
- [ ] `@adapttable/unstyled`
- [ ] `@adapttable/i18n`
- [ ] `@adapttable/cli`

## Checklist

- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` all pass.
- [ ] Added or updated tests for the change (coverage stays ~100%).
- [ ] Behaviour is consistent across the affected adapters.
- [ ] Added a changeset (`pnpm changeset`) describing the change for the release notes.
- [ ] Updated the docs / README if the public API or behaviour changed.
