### PR TITLE
chore: antd was missing from the PR template package list

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,7 @@
 - [ ] `@adapttable/mantine`
 - [ ] `@adapttable/mui`
 - [ ] `@adapttable/chakra`
+- [ ] `@adapttable/antd`
 - [ ] `@adapttable/unstyled`
 - [ ] `@adapttable/i18n`
 - [ ] `@adapttable/cli`


### PR DESCRIPTION
<!-- Thanks for contributing to AdaptTable! -->

## What does this PR do?

<!-- A short summary of the change and the motivation. Link any related issue: "Closes #123". -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [ ] Docs / chore / refactor (no runtime behaviour change)

## Affected packages

- [ ] `@adapttable/core`
- [ ] `@adapttable/mantine`
- [ ] `@adapttable/mui`
- [ ] `@adapttable/chakra`
- [ ] `@adapttable/unstyled`
- [ ] `@adapttable/i18n`
- [ ] `@adapttable/cli`

## Checklist

- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` all pass.
- [ ] Added or updated tests for the change (coverage stays ~100%).
- [ ] Behaviour is consistent across the affected adapters.
- [ ] Added a changeset (`pnpm changeset`) describing the change for the release notes.
- [ ] Updated the docs / README if the public API or behaviour changed.
