### PR TITLE
docs: inline <video> player in the root README hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@
 
 **Easy by default, infinitely customizable.** One unified data source for both client-side and server-side data, URL-synced shareable state, optional virtualization, infinite-scroll & paging (auto by device), responsive mobile cards, a real filter UX, **column management** (reorder · pin · resize · show/hide), first-class **i18n + RTL**, and seamless **dark mode** — out of the box.
 
-[![AdaptTable — the same data table re-rendered through Mantine, MUI, Chakra, Ant Design, Radix, shadcn, and Tailwind, from one headless engine](https://orwa-mahmoud.github.io/adapttable/media/demo-core-tour.png?v=2)](https://orwa-mahmoud.github.io/adapttable/media/demo-core-tour.mp4)
+<video src="https://orwa-mahmoud.github.io/adapttable/media/demo-core-tour.mp4" poster="https://orwa-mahmoud.github.io/adapttable/media/demo-core-tour.png?v=2" controls playsinline width="860">
+  <a href="https://orwa-mahmoud.github.io/adapttable/media/demo-core-tour.mp4">▶ Watch the 25-second tour — the same data table re-rendered through Mantine, MUI, Chakra, Ant Design, Radix, shadcn, and Tailwind, from one headless engine.</a>
+</video>
 
 </div>
 


### PR DESCRIPTION
The root README is GitHub-only (never published to npm), and GitHub renders inline <video>, so swap the click-to-open poster for a real in-page player — poster as the still frame, native controls, no autoplay. Package READMEs keep the poster→mp4 link since npm strips <video>.

<!-- Thanks for contributing to AdaptTable! -->

## What does this PR do?

<!-- A short summary of the change and the motivation. Link any related issue: "Closes #123". -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Docs / chore / refactor (no runtime behaviour change)

## Affected packages

- [ ] `@adapttable/core`
- [ ] `@adapttable/mantine`
- [ ] `@adapttable/mui`
- [ ] `@adapttable/chakra`
- [ ] `@adapttable/antd`
- [ ] `@adapttable/unstyled`
- [ ] `@adapttable/i18n`
- [ ] `@adapttable/cli`

## Checklist

- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` all pass.
- [ ] Added or updated tests for the change (coverage stays ~100%).
- [ ] Behaviour is consistent across the affected adapters.
- [ ] Added a changeset (`pnpm changeset`) describing the change for the release notes.
- [ ] Updated the docs / README if the public API or behaviour changed.
