### PR TITLE
docs: inline-play the README hero video (GitHub-hosted asset)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 
 **Easy by default, infinitely customizable.** One unified data source for both client-side and server-side data, URL-synced shareable state, optional virtualization, infinite-scroll & paging (auto by device), responsive mobile cards, a real filter UX, **column management** (reorder · pin · resize · show/hide), first-class **i18n + RTL**, and seamless **dark mode** — out of the box.
 
-<video src="https://orwa-mahmoud.github.io/adapttable/media/demo-core-tour.mp4" poster="https://orwa-mahmoud.github.io/adapttable/media/demo-core-tour.png?v=2" controls playsinline width="860">
-  <a href="https://orwa-mahmoud.github.io/adapttable/media/demo-core-tour.mp4">▶ Watch the 25-second tour — the same data table re-rendered through Mantine, MUI, Chakra, Ant Design, Radix, shadcn, and Tailwind, from one headless engine.</a>
+<video src="https://github.com/user-attachments/assets/1d59e6de-b201-4997-bcd5-beef1133c769" poster="https://orwa-mahmoud.github.io/adapttable/media/demo-core-tour.png?v=2" controls playsinline width="860">
+  <a href="https://github.com/user-attachments/assets/1d59e6de-b201-4997-bcd5-beef1133c769">▶ Watch the 25-second tour — the same data table re-rendered through Mantine, MUI, Chakra, Ant Design, Radix, shadcn, and Tailwind, from one headless engine.</a>
 </video>
 
 </div>


### PR DESCRIPTION
Swaps the hero `<video src>` from the Pages URL (which GitHub strips) to the GitHub-uploaded `user-attachments/assets/…` URL, so the player runs **in-page** on github.com. Root README is GitHub-only, so this never touches npm. No package change → no changeset.