### PR TITLE
fix(radix): render drawer filters mode as a real side drawer

### DIFF
--- a/.changeset/radix-drawer.md
+++ b/.changeset/radix-drawer.md
@@ -1,0 +1,11 @@
+---
+"@adapttable/radix": patch
+---
+
+Render `filtersMode="drawer"` as a real side drawer in the Radix adapter.
+
+Radix Themes ships no Drawer primitive, so the drawer previously fell back to a
+centered Dialog (a modal). It now pins to the inline-end edge at full height and
+slides in from that edge — RTL-correct via logical insets and honoring
+`prefers-reduced-motion` — while keeping the Dialog's backdrop, focus trap, and
+Escape / outside-click dismissal.

--- a/packages/adapter-radix/src/components/chrome.tsx
+++ b/packages/adapter-radix/src/components/chrome.tsx
@@ -462,6 +462,22 @@ export function FilterDrawer({
   accentColor?: RadixAccentColor;
   dir?: Direction;
 }>) {
+  // Radix Themes ships no Drawer primitive, so the drawer is a Dialog restyled
+  // into a full-height panel pinned to the inline-end edge (RTL-correct via
+  // logical insets) that slides in from that edge — instead of the centered
+  // modal Dialog renders by default. Injected as a <style> because keyframes
+  // can't be declared inline; the two-class selector + later source order
+  // outrank Radix's own centering/animation rules without `!important`.
+  const drawerClass = "adapttable-radix-drawer";
+  const fromEdge = dir === "rtl" ? "-100%" : "100%";
+  const drawerCss = `
+.${drawerClass}{position:fixed;inset-block:0;inset-inline-end:0;inset-inline-start:auto;margin:0;width:min(420px,100vw);max-width:none;height:100dvh;max-height:100dvh;border-radius:0;display:flex;flex-direction:column}
+.${drawerClass}[data-state="open"]{animation:${drawerClass}-in 220ms cubic-bezier(.32,.72,0,1)}
+.${drawerClass}[data-state="closed"]{animation:${drawerClass}-out 200ms cubic-bezier(.32,.72,0,1)}
+@keyframes ${drawerClass}-in{from{transform:translateX(${fromEdge})}to{transform:translateX(0)}}
+@keyframes ${drawerClass}-out{from{transform:translateX(0)}to{transform:translateX(${fromEdge})}}
+@media(prefers-reduced-motion:reduce){.${drawerClass}[data-state]{animation-duration:1ms}}
+`;
   return (
     <Dialog.Root
       open={open}
@@ -469,9 +485,15 @@ export function FilterDrawer({
         if (!next) onClose();
       }}
     >
-      <Dialog.Content dir={dir} maxWidth="420px">
+      <Dialog.Content dir={dir} className={drawerClass}>
+        <style>{drawerCss}</style>
         <Dialog.Title>{labels.filters}</Dialog.Title>
-        <Flex direction="column" gap="4" mt="3">
+        <Flex
+          direction="column"
+          gap="4"
+          mt="3"
+          style={{ flex: 1, minHeight: 0, overflowY: "auto" }}
+        >
           {filters}
         </Flex>
         <Flex justify="between" mt="4">


### PR DESCRIPTION
## What

`filtersMode="drawer"` in the Radix adapter rendered as a **centered modal**, not a drawer.

**Why:** Radix Themes (`@radix-ui/themes`) ships no `Drawer` primitive — only `Dialog`, which is centered by default. The `FilterDrawer` used `Dialog.Content` directly, so drawer mode looked identical to a modal. (Every other adapter has a native `Drawer`, so only Radix had this gap.)

## Fix

Restyle that `Dialog` into a real drawer while keeping the Dialog's backdrop, focus trap, and Escape / outside-click dismissal:

- **Edge-pinned, full-height** via logical insets (`inset-block: 0; inset-inline-end: 0`) — RTL-correct automatically.
- **Slides in from the edge** (`translateX`), direction flipped for RTL, `prefers-reduced-motion` honored.
- **Scrollable body** so long filter lists scroll inside the drawer; Clear-all / Done footer pinned at the bottom.

Injected as a `<style>` (keyframes can't be inline); a two-class selector + later source order outrank Radix's centering rules with no `!important`.

## Verification (Playwright)

| Check | LTR | RTL |
|---|---|---|
| Pinned to edge | right edge (`right = viewport`) | left edge (`left = 0`) |
| Full height | viewport height | viewport height |
| Centered (modal)? | no | no |
| Backdrop dims background | yes | yes |

Plus Escape-to-close verified. Gate green: lint, typecheck, 169 tests, coverage, build/publint, prettier — both `dir` arms covered by existing tests.