### PR TITLE
chore: freeze the public API for v1.0

### DIFF
--- a/.changeset/v1-0-0-freeze.md
+++ b/.changeset/v1-0-0-freeze.md
@@ -1,0 +1,21 @@
+---
+"@adapttable/core": major
+"@adapttable/mantine": major
+"@adapttable/mui": major
+"@adapttable/chakra": major
+"@adapttable/antd": major
+"@adapttable/radix": major
+"@adapttable/shadcn": major
+"@adapttable/unstyled": major
+"@adapttable/i18n": major
+---
+
+AdaptTable 1.0 — the public API is now stable under semantic versioning.
+
+This release freezes the committed-stable surface: the `@adapttable/core` engine
+(source builders, `useDataTable` and its prop-getters, the core types, and the
+URL-state hooks), every adapter's `<DataTable>` props and extension points
+(`slots`, `classNames`, `toolbar`, `confirm`), and the `@adapttable/i18n` locale
+presets. From this release on, breaking changes to that surface ship only in a
+major version. There are no runtime behavior changes — this marks the stability
+commitment. `@adapttable/cli` is a scaffolding tool and keeps its own cadence.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Hosted at **[orwa-mahmoud.github.io/adapttable](https://orwa-mahmoud.github.io/a
 
 ## Status
 
-🚧 **Pre-1.0, under active development.** Building in the open. APIs are stabilizing toward a `v1`. Follow the [roadmap](#roadmap).
+**Stable — `v1.0`.** The public API follows [semantic versioning](./docs/versioning.md): breaking changes ship only in a major release. See the [roadmap](#roadmap) for what's next.
 
 ## Roadmap
 
@@ -184,7 +184,7 @@ Hosted at **[orwa-mahmoud.github.io/adapttable](https://orwa-mahmoud.github.io/a
 - [x] Docs (markdown + `llms.txt`) + examples
 - [x] Hosted [docs site](https://orwa-mahmoud.github.io/adapttable/) + [live demo](https://orwa-mahmoud.github.io/adapttable/demo/) (GitHub Pages, deployed on every push to `main`)
 - [x] Optional row/card virtualization (windowing) for very large lists
-- [ ] `v1.0`
+- [x] `v1.0` — stable, semver-committed public API
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,8 +2,8 @@
 
 ## Supported versions
 
-AdaptTable is pre-1.0. Security fixes are applied to the latest released
-minor version. Once 1.0 ships, this policy will list the supported range.
+Security fixes are applied to the latest `1.x` release. We recommend staying on
+the latest published version of each `@adapttable/*` package.
 
 ## Reporting a vulnerability
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -11,8 +11,7 @@ Given `MAJOR.MINOR.PATCH`:
 - **PATCH** — bug fixes and internal improvements that don't change the
   public API. Always safe to adopt.
 - **MINOR** — new features and backwards-compatible changes. Code written
-  against the current minor keeps working on the next. (Before `1.0`, a minor
-  _may_ include breaking changes — see "Pre-1.0" below.)
+  against the current minor keeps working on the next.
 - **MAJOR** — breaking changes to the public API. We avoid these; when one is
   unavoidable, it ships in a major with a migration note in the CHANGELOG.
 
@@ -23,13 +22,13 @@ need to hunt for a compatible adapter/core pair — install the same version of
 each. `@adapttable/cli` is a scaffolding tool and stays on its own cadence; it
 is not part of the library surface.
 
-## Pre-1.0
+## Stability
 
-AdaptTable is pre-`1.0`. Until `1.0.0` ships, **minors may include breaking
-changes** (per the SemVer `0.x` convention, where `0.MINOR.PATCH` is treated as
-the "major" line). In practice breaking changes are rare and called out in the
-relevant package's `CHANGELOG.md`. Once `1.0.0` is tagged, the full SemVer
-contract above applies and breaking changes require a major bump.
+AdaptTable is **stable at `1.0`**. The full SemVer contract above applies:
+breaking changes to the public API surface (below) ship only in a major
+release, with a migration note in the relevant package's `CHANGELOG.md`. In
+practice such changes are rare — most releases are additive minors and safe
+patches.
 
 ## Public API surface
 
@@ -63,8 +62,7 @@ When an API is retired, it is **not** removed immediately:
 1. The deprecated API is marked `@deprecated` with a JSDoc note pointing to the
    replacement.
 2. It keeps working for **at least one minor** release (longer when practical).
-3. Removal happens in a **major** release (or, pre-`1.0`, in a minor with an
-   explicit CHANGELOG entry).
+3. Removal happens in a **major** release.
 
 We never silently remove a documented public API.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -17,8 +17,6 @@ You usually want a styled adapter on top (`@adapttable/mantine`,
 `@adapttable/core` directly when you want to render your own markup with full
 control via prop-getters.
 
-> 🚧 Pre-1.0, under active development.
-
 ## Documentation
 
 [Getting started](https://orwa-mahmoud.github.io/adapttable/getting-started/) · [Live demo](https://orwa-mahmoud.github.io/adapttable/demo/) · [Comparison vs ag-Grid · MUI X · TanStack](https://orwa-mahmoud.github.io/adapttable/comparison/)


### PR DESCRIPTION
Cuts AdaptTable to **1.0.0**.

## What
- **Major freeze changeset** (`.changeset/v1-0-0-freeze.md`) — bumps the changesets *fixed group* (core, all adapters, i18n) `0.3.3 → 1.0.0`. `@adapttable/cli` is excluded and keeps its own cadence (stays `0.2.0`).
- **Drops the pre-1.0 banners** and replaces them with stable-SemVer wording:
  - root `README.md` — Status section + roadmap checkbox
  - `packages/core/README.md` — removed the 🚧 blockquote
  - `docs/versioning.md` — "Pre-1.0" section → "Stability"; removed the pre-1.0 caveats in the minor/deprecation policy
  - `SECURITY.md` — supported-versions wording

## Release mechanics
Merging this lands the major changeset on `main`. The changesets bot then **force-updates the open "Version Packages" PR (#48) in place** — its diff flips from `0.3.4` to `1.0.0` (the pending radix-drawer patch folds into the major). Merging *that* refreshed PR publishes `1.0.0` to npm.

The existing drawer-fix patch on `main` is absorbed into this major — no interim `0.3.4` release.

## Verification
`pnpm exec changeset status --verbose` → all 9 library packages resolve to `1.0.0`; cli absent. Pre-commit gate green.