### PR TITLE
feat(starters): per-adapter StackBlitz starters + "Open in StackBlitz" doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ npx @adapttable/cli init
 pnpm add @adapttable/core @adapttable/mantine
 ```
 
+**Try it first, no install:** [open a live starter in StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine) (Mantine) — or [any other kit](https://orwa-mahmoud.github.io/adapttable/getting-started/#try-it-in-stackblitz).
+
 ## The big idea: `TableSource`
 
 Every data source — in-memory or server-paginated — fulfils one contract. The table is agnostic to where rows came from:

--- a/docs/column-management.md
+++ b/docs/column-management.md
@@ -1,5 +1,7 @@
 # Column management
 
+▶ **Try it live:** [open a Mantine starter in StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine) — a real AdaptTable you can edit in the browser, no install. [Other UI kits →](./getting-started.md#try-it-in-stackblitz)
+
 <video src="https://orwa-mahmoud.github.io/adapttable/media/demo-pinning.mp4" autoplay loop muted playsinline style="width:100%;border-radius:8px"></video>
 
 Let users show/hide, reorder, pin, and resize columns — one prop per capability, with the resulting layout persistable to the URL or localStorage. Every adapter shares the same engine from `@adapttable/core`.

--- a/docs/columns.md
+++ b/docs/columns.md
@@ -1,5 +1,7 @@
 # Columns
 
+▶ **Try it live:** [open a Mantine starter in StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine) — a real AdaptTable you can edit in the browser, no install. [Other UI kits →](./getting-started.md#try-it-in-stackblitz)
+
 Columns are plain objects — declare a `key` and the table renders the value, derives the header, and wires sorting and filtering around it. Everything beyond the key is an opt-in refinement.
 
 ## Example

--- a/docs/filtering.md
+++ b/docs/filtering.md
@@ -1,5 +1,7 @@
 # Filtering
 
+▶ **Try it live:** [open a Mantine starter in StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine) — a real AdaptTable you can edit in the browser, no install. [Other UI kits →](./getting-started.md#try-it-in-stackblitz)
+
 Declare a filter once and AdaptTable derives everything from it: the
 kit-native widget, the `f_<key>` URL param, the removable chip, and (on
 frontend data) the row predicate — no wiring.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,8 +26,8 @@ pnpm add @adapttable/core @adapttable/mantine @mantine/core @mantine/hooks
 # Material UI
 pnpm add @adapttable/core @adapttable/mui @mui/material
 
-# Chakra UI (v2 — pin Chakra v2; v3 support hasn't landed yet)
-pnpm add @adapttable/core @adapttable/chakra @chakra-ui/react@2 @emotion/react
+# Chakra UI (v3)
+pnpm add @adapttable/core @adapttable/chakra @chakra-ui/react @emotion/react
 
 # Ant Design
 pnpm add @adapttable/core @adapttable/antd antd
@@ -67,12 +67,13 @@ import { createTheme, ThemeProvider } from "@mui/material";
 </ThemeProvider>;
 ```
 
-**Chakra UI**
+**Chakra UI** (v3) — the provider takes a system; use the built-in
+`defaultSystem` or your own:
 
 ```tsx
-import { ChakraProvider } from "@chakra-ui/react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 
-<ChakraProvider>
+<ChakraProvider value={defaultSystem}>
   <App />
 </ChakraProvider>;
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -175,6 +175,23 @@ filter also drives its own removable chip, URL parsing, and row predicate.
 />
 ```
 
+## Try it in StackBlitz
+
+Prefer to try before installing? Each starter is a minimal Vite app — one table
+on a demo dataset — that boots in the browser with no local setup. Pick your
+kit:
+
+- [Mantine](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine)
+- [Material UI](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mui)
+- [Chakra UI](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/chakra)
+- [Ant Design](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/antd)
+- [Radix Themes](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/radix)
+- [shadcn/ui](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/shadcn)
+- [Unstyled / Tailwind](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/unstyled)
+
+The source for each lives in
+[`starters/`](https://github.com/orwa-mahmoud/adapttable/tree/main/starters).
+
 ## Where next
 
 - [Columns](./columns.md) — headers, custom cells, the Columns menu

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -1,5 +1,7 @@
 # Pagination
 
+▶ **Try it live:** [open a Mantine starter in StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine) — a real AdaptTable you can edit in the browser, no install. [Other UI kits →](./getting-started.md#try-it-in-stackblitz)
+
 Every table paginates out of the box. Choose between a classic paged footer,
 infinite scroll, or `"auto"` (the default), which picks per device.
 

--- a/docs/row-expansion.md
+++ b/docs/row-expansion.md
@@ -1,5 +1,7 @@
 # Row expansion
 
+▶ **Try it live:** [open a Mantine starter in StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine) — a real AdaptTable you can edit in the browser, no install. [Other UI kits →](./getting-started.md#try-it-in-stackblitz)
+
 Render a detail panel under any row by passing `renderRowDetail` — its
 presence is the whole API.
 

--- a/docs/saved-views.md
+++ b/docs/saved-views.md
@@ -1,5 +1,7 @@
 # Saved views
 
+▶ **Try it live:** [open a Mantine starter in StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine) — a real AdaptTable you can edit in the browser, no install. [Other UI kits →](./getting-started.md#try-it-in-stackblitz)
+
 Let users capture the table's current state — search, sort, page, filters,
 column layout — under a name and re-apply it later. One prop mounts a
 ready-made menu; a headless hook backs custom UIs.

--- a/docs/selection.md
+++ b/docs/selection.md
@@ -1,5 +1,7 @@
 # Selection & bulk actions
 
+▶ **Try it live:** [open a Mantine starter in StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine) — a real AdaptTable you can edit in the browser, no install. [Other UI kits →](./getting-started.md#try-it-in-stackblitz)
+
 Pass `bulkActions` and row selection turns on: checkboxes on every row, a
 tri-state header checkbox, and a selection toolbar with your action buttons.
 No other wiring is required.

--- a/docs/sorting.md
+++ b/docs/sorting.md
@@ -1,5 +1,7 @@
 # Sorting
 
+▶ **Try it live:** [open a Mantine starter in StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine) — a real AdaptTable you can edit in the browser, no install. [Other UI kits →](./getting-started.md#try-it-in-stackblitz)
+
 Mark a column `sortable` and header clicks cycle it ascending → descending → cleared, with the state kept in the URL so reloads and shared links restore the exact order. Multi-column sorting is one extra prop.
 
 ## Example

--- a/docs/virtualization.md
+++ b/docs/virtualization.md
@@ -1,5 +1,7 @@
 # Virtualization
 
+▶ **Try it live:** [open a Mantine starter in StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine) — a real AdaptTable you can edit in the browser, no install. [Other UI kits →](./getting-started.md#try-it-in-stackblitz)
+
 <video src="https://orwa-mahmoud.github.io/adapttable/media/demo-scale.mp4" autoplay loop muted playsinline style="width:100%;border-radius:8px"></video>
 
 Long lists can opt into row/card windowing with one prop: `virtualize`. Fifty

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -182,6 +182,23 @@ filter also drives its own removable chip, URL parsing, and row predicate.
 />
 ```
 
+## Try it in StackBlitz
+
+Prefer to try before installing? Each starter is a minimal Vite app — one table
+on a demo dataset — that boots in the browser with no local setup. Pick your
+kit:
+
+- [Mantine](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine)
+- [Material UI](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mui)
+- [Chakra UI](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/chakra)
+- [Ant Design](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/antd)
+- [Radix Themes](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/radix)
+- [shadcn/ui](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/shadcn)
+- [Unstyled / Tailwind](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/unstyled)
+
+The source for each lives in
+[`starters/`](https://github.com/orwa-mahmoud/adapttable/tree/main/starters).
+
 ## Where next
 
 - [Columns](./columns.md) — headers, custom cells, the Columns menu
@@ -558,6 +575,8 @@ See it live in the [demo](https://orwa-mahmoud.github.io/adapttable/demo/).
 
 # Columns
 
+▶ **Try it live:** [open a Mantine starter in StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine) — a real AdaptTable you can edit in the browser, no install. [Other UI kits →](./getting-started.md#try-it-in-stackblitz)
+
 Columns are plain objects — declare a `key` and the table renders the value, derives the header, and wires sorting and filtering around it. Everything beyond the key is an opt-in refinement.
 
 ## Example
@@ -689,6 +708,8 @@ See it live in the [demo](https://orwa-mahmoud.github.io/adapttable/demo/).
 
 # Sorting
 
+▶ **Try it live:** [open a Mantine starter in StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine) — a real AdaptTable you can edit in the browser, no install. [Other UI kits →](./getting-started.md#try-it-in-stackblitz)
+
 Mark a column `sortable` and header clicks cycle it ascending → descending → cleared, with the state kept in the URL so reloads and shared links restore the exact order. Multi-column sorting is one extra prop.
 
 ## Example
@@ -803,6 +824,8 @@ See it live in the [demo](https://orwa-mahmoud.github.io/adapttable/demo/).
 ---
 
 # Filtering
+
+▶ **Try it live:** [open a Mantine starter in StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine) — a real AdaptTable you can edit in the browser, no install. [Other UI kits →](./getting-started.md#try-it-in-stackblitz)
 
 Declare a filter once and AdaptTable derives everything from it: the
 kit-native widget, the `f_<key>` URL param, the removable chip, and (on
@@ -987,6 +1010,8 @@ See it live in the [demo](https://orwa-mahmoud.github.io/adapttable/demo/).
 
 # Pagination
 
+▶ **Try it live:** [open a Mantine starter in StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine) — a real AdaptTable you can edit in the browser, no install. [Other UI kits →](./getting-started.md#try-it-in-stackblitz)
+
 Every table paginates out of the box. Choose between a classic paged footer,
 infinite scroll, or `"auto"` (the default), which picks per device.
 
@@ -1065,6 +1090,8 @@ See it live in the [demo](https://orwa-mahmoud.github.io/adapttable/demo/).
 ---
 
 # Selection & bulk actions
+
+▶ **Try it live:** [open a Mantine starter in StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine) — a real AdaptTable you can edit in the browser, no install. [Other UI kits →](./getting-started.md#try-it-in-stackblitz)
 
 Pass `bulkActions` and row selection turns on: checkboxes on every row, a
 tri-state header checkbox, and a selection toolbar with your action buttons.
@@ -1203,6 +1230,8 @@ See it live in the [demo](https://orwa-mahmoud.github.io/adapttable/demo/).
 
 # Row expansion
 
+▶ **Try it live:** [open a Mantine starter in StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine) — a real AdaptTable you can edit in the browser, no install. [Other UI kits →](./getting-started.md#try-it-in-stackblitz)
+
 Render a detail panel under any row by passing `renderRowDetail` — its
 presence is the whole API.
 
@@ -1282,6 +1311,8 @@ See it live in the [demo](https://orwa-mahmoud.github.io/adapttable/demo/).
 ---
 
 # Column management
+
+▶ **Try it live:** [open a Mantine starter in StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine) — a real AdaptTable you can edit in the browser, no install. [Other UI kits →](./getting-started.md#try-it-in-stackblitz)
 
 <video src="https://orwa-mahmoud.github.io/adapttable/media/demo-pinning.mp4" autoplay loop muted playsinline style="width:100%;border-radius:8px"></video>
 
@@ -1397,6 +1428,8 @@ See it live in the [demo](https://orwa-mahmoud.github.io/adapttable/demo/).
 ---
 
 # Saved views
+
+▶ **Try it live:** [open a Mantine starter in StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine) — a real AdaptTable you can edit in the browser, no install. [Other UI kits →](./getting-started.md#try-it-in-stackblitz)
 
 Let users capture the table's current state — search, sort, page, filters,
 column layout — under a name and re-apply it later. One prop mounts a
@@ -1531,6 +1564,8 @@ See it live in the [demo](https://orwa-mahmoud.github.io/adapttable/demo/).
 ---
 
 # Virtualization
+
+▶ **Try it live:** [open a Mantine starter in StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine) — a real AdaptTable you can edit in the browser, no install. [Other UI kits →](./getting-started.md#try-it-in-stackblitz)
 
 <video src="https://orwa-mahmoud.github.io/adapttable/media/demo-scale.mp4" autoplay loop muted playsinline style="width:100%;border-radius:8px"></video>
 
@@ -2368,28 +2403,28 @@ On or after / On or before / Between) — headless: `readRangeWidget`,
 
 Props beyond the core surface, with per-kit availability.
 
-| Prop            | Type                                            | Default     | Available on              | Description                                                                                                                 |
-| --------------- | ----------------------------------------------- | ----------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `data`          | `readonly TRow[]`                               | —           | all                       | Frontend tier: raw rows the table filters/sorts/pages; with `onQueryChange` it is the current server page.                  |
-| `total`         | `number`                                        | —           | all                       | Server tier: total row count across all pages (drives the pager).                                                           |
-| `loading`       | `boolean`                                       | —           | all                       | Server tier: a request is in flight.                                                                                        |
-| `onQueryChange` | `(query: TableQuery, info: { signal }) => void` | —           | all                       | Server tier: fired with the consolidated query whenever it changes (mount included); fetch and hand back `data` + `total`.  |
-| `urlKey`        | `string`                                        | —           | all                       | Namespace for this table's URL params (`urlKey="left"` → `left.q`, `left.page`, …).                                         |
-| `urlAdapter`    | `UrlStateAdapter`                               | History API | all                       | URL-state backend for the `data`/`onQueryChange` tiers (router adapter, `createMemoryAdapter()` in tests).                  |
-| `urlSync`       | `boolean`                                       | `true`      | all                       | `false` keeps all state in memory — the address bar never changes, any `urlAdapter` is ignored.                             |
-| `savedViews`    | `UseSavedViewsOptions`                          | —           | all                       | Mounts a saved-views toolbar menu; `adapter`/`urlKey` default to the table's own, so usually only `storageKey` is needed.   |
-| `slots`         | `{ skeleton?, empty? }`                         | —           | all                       | Replace sub-components (loading skeleton, empty state).                                                                     |
+| Prop            | Type                                            | Default     | Available on                     | Description                                                                                                                       |
+| --------------- | ----------------------------------------------- | ----------- | -------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `data`          | `readonly TRow[]`                               | —           | all                              | Frontend tier: raw rows the table filters/sorts/pages; with `onQueryChange` it is the current server page.                        |
+| `total`         | `number`                                        | —           | all                              | Server tier: total row count across all pages (drives the pager).                                                                 |
+| `loading`       | `boolean`                                       | —           | all                              | Server tier: a request is in flight.                                                                                              |
+| `onQueryChange` | `(query: TableQuery, info: { signal }) => void` | —           | all                              | Server tier: fired with the consolidated query whenever it changes (mount included); fetch and hand back `data` + `total`.        |
+| `urlKey`        | `string`                                        | —           | all                              | Namespace for this table's URL params (`urlKey="left"` → `left.q`, `left.page`, …).                                               |
+| `urlAdapter`    | `UrlStateAdapter`                               | History API | all                              | URL-state backend for the `data`/`onQueryChange` tiers (router adapter, `createMemoryAdapter()` in tests).                        |
+| `urlSync`       | `boolean`                                       | `true`      | all                              | `false` keeps all state in memory — the address bar never changes, any `urlAdapter` is ignored.                                   |
+| `savedViews`    | `UseSavedViewsOptions`                          | —           | all                              | Mounts a saved-views toolbar menu; `adapter`/`urlKey` default to the table's own, so usually only `storageKey` is needed.         |
+| `slots`         | `{ skeleton?, empty? }`                         | —           | all                              | Replace sub-components (loading skeleton, empty state).                                                                           |
 | `classNames`    | `DataTableClassNames`                           | —           | mantine, chakra, radix, unstyled | Per-part class overrides — five parts on Mantine/Chakra/Radix (`root`/`toolbar`/`table`/`card`/`footer`), every part on unstyled. |
-| `className`     | `string`                                        | —           | mui, antd                 | Class name applied to the root wrapper.                                                                                     |
-| `animate`       | `boolean`                                       | `false`     | mantine                   | Animate rows/cards on mount (dependency-free; honors reduced motion).                                                       |
-| `size`          | kit-specific union                              | —           | mui, chakra, antd, radix  | Explicit kit table size, overriding the size derived from `density` (chakra default `"md"`; radix `"2"`, compact `"1"`).    |
-| `colorScheme`   | `string`                                        | —           | chakra                    | Chakra color scheme for primary accents (buttons, badges).                                                                  |
-| `accentColor`   | `RadixAccentColor`                              | —           | radix                     | Radix accent color for primary controls (buttons, badges, active page).                                                     |
-| `bordered`      | `boolean`                                       | `false`     | antd                      | Render the table with cell borders.                                                                                         |
-| `virtualHeight` | `number`                                        | `480`       | antd                      | Vertical scroll height used when `virtualize` is true.                                                                      |
-| `virtualWidth`  | `number`                                        | `960`       | antd                      | Horizontal scroll width used when `virtualize` is true.                                                                     |
-| `emptyState`    | `ReactNode`                                     | —           | unstyled                  | Empty-state node override (`slots.empty` alias wins when both are set).                                                     |
-| `loadingState`  | `ReactNode`                                     | —           | unstyled                  | Loading-state node override (`slots.skeleton` alias wins when both are set).                                                |
+| `className`     | `string`                                        | —           | mui, antd                        | Class name applied to the root wrapper.                                                                                           |
+| `animate`       | `boolean`                                       | `false`     | mantine                          | Animate rows/cards on mount (dependency-free; honors reduced motion).                                                             |
+| `size`          | kit-specific union                              | —           | mui, chakra, antd, radix         | Explicit kit table size, overriding the size derived from `density` (chakra default `"md"`; radix `"2"`, compact `"1"`).          |
+| `colorScheme`   | `string`                                        | —           | chakra                           | Chakra color scheme for primary accents (buttons, badges).                                                                        |
+| `accentColor`   | `RadixAccentColor`                              | —           | radix                            | Radix accent color for primary controls (buttons, badges, active page).                                                           |
+| `bordered`      | `boolean`                                       | `false`     | antd                             | Render the table with cell borders.                                                                                               |
+| `virtualHeight` | `number`                                        | `480`       | antd                             | Vertical scroll height used when `virtualize` is true.                                                                            |
+| `virtualWidth`  | `number`                                        | `960`       | antd                             | Horizontal scroll width used when `virtualize` is true.                                                                           |
+| `emptyState`    | `ReactNode`                                     | —           | unstyled                         | Empty-state node override (`slots.empty` alias wins when both are set).                                                           |
+| `loadingState`  | `ReactNode`                                     | —           | unstyled                         | Loading-state node override (`slots.skeleton` alias wins when both are set).                                                      |
 
 Each adapter also re-exports the core source builders and types, so one
 import path covers everything.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -33,8 +33,8 @@ pnpm add @adapttable/core @adapttable/mantine @mantine/core @mantine/hooks
 # Material UI
 pnpm add @adapttable/core @adapttable/mui @mui/material
 
-# Chakra UI (v2 — pin Chakra v2; v3 support hasn't landed yet)
-pnpm add @adapttable/core @adapttable/chakra @chakra-ui/react@2 @emotion/react
+# Chakra UI (v3)
+pnpm add @adapttable/core @adapttable/chakra @chakra-ui/react @emotion/react
 
 # Ant Design
 pnpm add @adapttable/core @adapttable/antd antd
@@ -74,12 +74,13 @@ import { createTheme, ThemeProvider } from "@mui/material";
 </ThemeProvider>;
 ```
 
-**Chakra UI**
+**Chakra UI** (v3) — the provider takes a system; use the built-in
+`defaultSystem` or your own:
 
 ```tsx
-import { ChakraProvider } from "@chakra-ui/react";
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 
-<ChakraProvider>
+<ChakraProvider value={defaultSystem}>
   <App />
 </ChakraProvider>;
 ```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 9.39.4
       '@rolldown/plugin-babel':
         specifier: ^0.2.3
-        version: 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
+        version: 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
       '@rollup/plugin-babel':
         specifier: ^7.1.0
         version: 7.1.0(@babel/core@7.29.7)(@types/babel__core@7.20.5)(rollup@4.62.0)
@@ -49,7 +49,7 @@ importers:
         version: 8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
+        version: 6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
       '@vitest/coverage-v8':
         specifier: ^4.1.8
         version: 4.1.8(vitest@4.1.8)
@@ -112,7 +112,7 @@ importers:
         version: 8.61.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
+        version: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
 
   apps/docs:
     dependencies:
@@ -206,7 +206,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^6.0.2
-        version: 6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
+        version: 6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
       tailwindcss:
         specifier: ^4.3.1
         version: 4.3.1
@@ -589,7 +589,319 @@ importers:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
 
+  starters/antd:
+    dependencies:
+      '@adapttable/antd':
+        specifier: ^1.0.0
+        version: 1.0.0(antd@6.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@adapttable/core':
+        specifier: ^1.0.0
+        version: 1.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      antd:
+        specifier: ^6.5.0
+        version: 6.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.3
+        version: 6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.1.3
+        version: 8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)
+
+  starters/chakra:
+    dependencies:
+      '@adapttable/chakra':
+        specifier: ^1.0.0
+        version: 1.0.0(@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@adapttable/core':
+        specifier: ^1.0.0
+        version: 1.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@chakra-ui/react':
+        specifier: ^3.36.0
+        version: 3.36.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@emotion/react':
+        specifier: ^11.14.0
+        version: 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.3
+        version: 6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.1.3
+        version: 8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)
+
+  starters/mantine:
+    dependencies:
+      '@adapttable/core':
+        specifier: ^1.0.0
+        version: 1.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@adapttable/mantine':
+        specifier: ^1.0.0
+        version: 1.0.0(@mantine/core@9.4.1(@mantine/hooks@9.4.1(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mantine/hooks@9.4.1(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mantine/core':
+        specifier: ^9.4.1
+        version: 9.4.1(@mantine/hooks@9.4.1(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mantine/hooks':
+        specifier: ^9.4.1
+        version: 9.4.1(react@19.2.7)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.3
+        version: 6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.1.3
+        version: 8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)
+
+  starters/mui:
+    dependencies:
+      '@adapttable/core':
+        specifier: ^1.0.0
+        version: 1.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@adapttable/mui':
+        specifier: ^1.0.0
+        version: 1.0.0(@mui/material@9.2.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@emotion/react':
+        specifier: ^11.14.0
+        version: 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled':
+        specifier: ^11.14.1
+        version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/material':
+        specifier: ^9.2.0
+        version: 9.2.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.3
+        version: 6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.1.3
+        version: 8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)
+
+  starters/radix:
+    dependencies:
+      '@adapttable/core':
+        specifier: ^1.0.0
+        version: 1.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@adapttable/radix':
+        specifier: ^1.0.0
+        version: 1.0.0(@radix-ui/themes@3.3.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/themes':
+        specifier: ^3.3.0
+        version: 3.3.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.3
+        version: 6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.1.3
+        version: 8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)
+
+  starters/shadcn:
+    dependencies:
+      '@adapttable/core':
+        specifier: ^1.0.0
+        version: 1.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@adapttable/shadcn':
+        specifier: ^1.0.0
+        version: 1.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.3.2
+        version: 4.3.2(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.3
+        version: 6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
+      tailwindcss:
+        specifier: ^4.3.2
+        version: 4.3.2
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.1.3
+        version: 8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)
+
+  starters/unstyled:
+    dependencies:
+      '@adapttable/core':
+        specifier: ^1.0.0
+        version: 1.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@adapttable/unstyled':
+        specifier: ^1.0.0
+        version: 1.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.3
+        version: 6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.1.3
+        version: 8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)
+
 packages:
+
+  '@adapttable/antd@1.0.0':
+    resolution: {integrity: sha512-LjE6DlvlZHYNeo3mWsf3rkswZtfhptXn2QsTpScBArd8jqrrYAhZTVmddlDC6JMVw5QNEhjAuqbAjMpCYpNhiw==}
+    engines: {node: '>=18.18.0'}
+    peerDependencies:
+      antd: ^6.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@adapttable/chakra@1.0.0':
+    resolution: {integrity: sha512-pJUI3cRgdVjBpew110+Uk4gOPESEMHFLFHPBwV1vG3FDuX102pkzFQO1+6Yb8vKu8THP+ZV8FjiI6YLe/Niq1g==}
+    engines: {node: '>=18.18.0'}
+    peerDependencies:
+      '@chakra-ui/react': ^3.0.0
+      '@emotion/react': ^11.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@adapttable/core@1.0.0':
+    resolution: {integrity: sha512-EYOacN0nZ6dapMG2xGnRzZuMnXVAzDfBx16z8yIJGRuwzgYButufl+49YNSKmXg2c+nqefNtub9TqvVfdYLV+w==}
+    engines: {node: '>=18.18.0'}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+
+  '@adapttable/mantine@1.0.0':
+    resolution: {integrity: sha512-UkLpQYrF5weIYNBPF5Q9K5P09KbtzKymPw3w8q51U1kD+xRplO681cdOJawI0IXvS+jvfoEAqnD+1mtr+ifHOg==}
+    engines: {node: '>=18.18.0'}
+    peerDependencies:
+      '@mantine/core': ^7.0.0 || ^8.0.0 || ^9.0.0
+      '@mantine/hooks': ^7.0.0 || ^8.0.0 || ^9.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@adapttable/mui@1.0.0':
+    resolution: {integrity: sha512-wmmDGutWVgif2S081Uy3KWUaBCm6x8FcGSgek7lHqhiCZMxZiopqbXMNYLhKrIrlTzOxHqTXMfqmnSMCAJ1Ddg==}
+    engines: {node: '>=18.18.0'}
+    peerDependencies:
+      '@mui/material': ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@adapttable/radix@1.0.0':
+    resolution: {integrity: sha512-nr+ji7N++i2nODlSXj7K7i7sMrQ/nynHauHQSaF0fd/haIe09PpG8Op3e2fDqGtD5sZ/7kS4DZ+1nFqaKxZ2aQ==}
+    engines: {node: '>=18.18.0'}
+    peerDependencies:
+      '@radix-ui/themes': ^3.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@adapttable/shadcn@1.0.0':
+    resolution: {integrity: sha512-RtgqwMzfkTGzwI5ZA05MylWoWt6tl5N+Qd10zUNlrn+xnzFL2o1L+QrQVlR+BZKTgHJMxr6m7iOmLdfo2WMjgw==}
+    engines: {node: '>=18.18.0'}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@adapttable/unstyled@1.0.0':
+    resolution: {integrity: sha512-z+/h6jKc0mEz/6JMYVxqE+pCV+8Hju8efiYnhCRldzdk6WbAtDRBMrJRZJfgKQ7PRwaooyIxk7H6LslB4Yi5LQ==}
+    engines: {node: '>=18.18.0'}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
 
   '@adobe/css-tools@4.5.0':
     resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
@@ -616,8 +928,18 @@ packages:
   '@ant-design/icons-svg@4.4.2':
     resolution: {integrity: sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==}
 
+  '@ant-design/icons-svg@4.5.0':
+    resolution: {integrity: sha512-1BTUFyKPTBZ53MuTP8s0k5SFEXL7o3VHEOwLgzaoWKwnBeqIcqUtVshc4SKzhI6uACfqhJqBwBUE9FsWR3uULA==}
+
   '@ant-design/icons@6.2.5':
     resolution: {integrity: sha512-0hKtoKqTjGFOndUyJLJmC9Cg6k4rEO7rLo6xmgbNJH+/ZX1C57RVals2v1j1knHl9n7Q+sBOveTvn931wLOCKw==}
+    engines: {node: '>=8'}
+    peerDependencies:
+      react: '>=16.0.0'
+      react-dom: '>=16.0.0'
+
+  '@ant-design/icons@6.3.2':
+    resolution: {integrity: sha512-B6O5a5XJ4wjtNOfZejXYwHW5zvKV5gYkjGf11dHGLEbKn0ABDGndo41+gfIiXyTFhvESj4XTotuud33mUFid0g==}
     engines: {node: '>=8'}
     peerDependencies:
       react: '>=16.0.0'
@@ -970,6 +1292,9 @@ packages:
 
   '@emnapi/core@1.11.0':
     resolution: {integrity: sha512-l9Oo58x0HOP5znGzVhYW9U3e5wVuA4LAZU2AGezTmkhO1CgQRFDhDg4nneHsu/t3WniXg9QrG2nIXL/ZS8ln8Q==}
+
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
 
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
@@ -1651,8 +1976,20 @@ packages:
       react: ^19.2.0
       react-dom: ^19.2.0
 
+  '@mantine/core@9.4.1':
+    resolution: {integrity: sha512-lZWEICrum4+vwKxzh/mk4RB1N6BqZ0Cshdl6lhm7OYLiQzmOaxKtOgyaWz+vr65G8mqTXjalZalB+wmMVBYK2Q==}
+    peerDependencies:
+      '@mantine/hooks': 9.4.1
+      react: ^19.2.0
+      react-dom: ^19.2.0
+
   '@mantine/hooks@9.3.1':
     resolution: {integrity: sha512-zAOlxV59j5CDgAnExN+ypaR6dVW1vwMKDvKUxIlUVd/e52qxYnPyYRD+shJmyOLaZRuQmVF0R/7mJAjt2jw9cA==}
+    peerDependencies:
+      react: ^19.2.0
+
+  '@mantine/hooks@9.4.1':
+    resolution: {integrity: sha512-eTI8wmzPx3r98zgKIEuvukmoGTHBhmtI6+9E6o2DbTmEU2eM1bCdjE2vFdf0op2AlRO0KEYEcZhNQi4T/SJk0A==}
     peerDependencies:
       react: ^19.2.0
 
@@ -1667,6 +2004,9 @@ packages:
 
   '@mui/core-downloads-tracker@9.1.1':
     resolution: {integrity: sha512-AupmMICbdJHqAh6FfOMaaiiIr7dfEgZJn5DFfiPuGNrbs+ZZy9cD1APwO0TSVBz5j08MJEEY6n7iC76/2wjMEA==}
+
+  '@mui/core-downloads-tracker@9.2.0':
+    resolution: {integrity: sha512-+XMav+ZaXkZKUFUgzjrfMEedfyJKxxviAske2q8N8CWDMeqZdDU2lWMkiUPiB388hGaDqhwvOAwkrsc/pUyp8g==}
 
   '@mui/material@9.1.1':
     resolution: {integrity: sha512-Wv+gInjrpf99l1Q0oHe0eOWGTnlbkzs5nowClX65KCT/2fyPMwcbFEEkUsOHdpcHhB5UAbz/d7jlwt5ajWVvlA==}
@@ -1688,8 +2028,38 @@ packages:
       '@types/react':
         optional: true
 
+  '@mui/material@9.2.0':
+    resolution: {integrity: sha512-+YTRSgGKGrrRo2XJZXs7JRA6qHoHWvNtxyqxnrRJTBmIuLOUpxxh7m4G9lF4tWberxGFY+EqkkRPgJCl+fSMJg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@mui/material-pigment-css': ^9.2.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@mui/material-pigment-css':
+        optional: true
+      '@types/react':
+        optional: true
+
   '@mui/private-theming@9.1.1':
     resolution: {integrity: sha512-oH6c+d6sJ1CZT0Vg2/fHdUQ5zvo9Pn+f+WWk0tlQliHqqIRdN32DZ7UxjalW3LUj4OkHbdWR31biWuLxK9i7Cg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@mui/private-theming@9.2.0':
+    resolution: {integrity: sha512-w9wpyDxGPGnAACPB2hKhCDmILJIAvQxrfjUbIAEa0AznX1rOjaz5N+yB1uuw8ixnJcpEh/tPbD9oEe19wcWPHw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -1727,6 +2097,22 @@ packages:
       '@types/react':
         optional: true
 
+  '@mui/system@9.2.0':
+    resolution: {integrity: sha512-YvUJwKoGVtbnOm2PyPi5TvX2d1rOA6sqSpEWVs4WmXNIaFTuYmNUaVdU2o1NKUEe31URnD3E8ZVUMcsLQXwcYg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.5.0
+      '@emotion/styled': ^11.3.0
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+      '@types/react':
+        optional: true
+
   '@mui/types@9.1.1':
     resolution: {integrity: sha512-Zjt7u8wNvDg40rPTGoL+TnfkpuSKjwubsNSFRH1KAVZLcaV4I3AFNHIFbvH7p4F3alEibSbdd90xAgn5Rnfndg==}
     peerDependencies:
@@ -1745,8 +2131,24 @@ packages:
       '@types/react':
         optional: true
 
+  '@mui/utils@9.2.0':
+    resolution: {integrity: sha512-OsUH5zhlSOM4xmLl53+agug1M1UyWb4zxFxWQCqwKTKUeQPvTENtg3JhrroBD2qpCLKsX5W/DYGERJ4mBUbc8g==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@napi-rs/wasm-runtime@1.1.5':
     resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
     peerDependencies:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
@@ -1771,6 +2173,9 @@ packages:
 
   '@oxc-project/types@0.135.0':
     resolution: {integrity: sha512-wR+xRdFkUBMvcAjBJ2q2kcZM6d+DKu2NgoOyxZgYwZdLhmiv6+rnO8PZ/P68kMiZtIKm+pW7zyEJ4kSOs0vo+Q==}
+
+  '@oxc-project/types@0.138.0':
+    resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
 
   '@pagefind/darwin-arm64@1.5.2':
     resolution: {integrity: sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ==}
@@ -2540,6 +2945,12 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
+  '@rc-component/cascader@1.17.0':
+    resolution: {integrity: sha512-3cVNG0zrQF1PoXq262L3wGCU+/YLEC1mGSVHDl577dQmA0ZKkXFbY6nwyXo+beCcM7buo49t24jkr+QZdL7O8w==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
   '@rc-component/checkbox@2.0.0':
     resolution: {integrity: sha512-3CXGPpAR9gsPKeO2N78HAPOzU30UdemD6HGJoWVJOpa6WleaGB5kzZj3v6bdTZab31YuWgY/RxV3VKPctn0DwQ==}
     peerDependencies:
@@ -2560,6 +2971,12 @@ packages:
 
   '@rc-component/context@2.0.2':
     resolution: {integrity: sha512-uiGpAlblCNlziHPwj4S4Iy/oemeuz/hR03mbiEjTCXwsqOIN3BOzsRMyDwpyO5Fm0vIEEJRUf9ZtbRLbhksuTA==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
+  '@rc-component/dialog@1.10.0':
+    resolution: {integrity: sha512-eDukNlz9vNszAGv7i3zKXdxEd3wgVmNxuJijYt8zvTh17QwTu8KK/bdURRd/lU4qaMzhO1HKKmMrwOnkaw0BvQ==}
     peerDependencies:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
@@ -2589,6 +3006,13 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
+  '@rc-component/form@1.8.5':
+    resolution: {integrity: sha512-d24EYtvUOBhxEtSd/EqIu9DaMuqrWF2IRIvAFCTM6NQ/GJIYNr8DvEpUSUlv2uPxEJ0ZPwYQ+wwlGIAaiHvdrw==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
   '@rc-component/image@1.9.0':
     resolution: {integrity: sha512-khF7w7xkBH5B1bsBcI1FSUZdkyd1aqpl2eYyILCqCzzQH3XdfehGUaZTnptyaJJfs09/R5hv9jXWyazOMFIClQ==}
     peerDependencies:
@@ -2607,6 +3031,12 @@ packages:
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
 
+  '@rc-component/mentions@1.10.0':
+    resolution: {integrity: sha512-CI1njYUVY0NjHtLhNoVmXlJyy568Sfep9Wsak6vmGjtT6uazx98djGYlCXz2xkHhEm73g91Y3MTvzUyE5avI7w==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
   '@rc-component/mentions@1.9.0':
     resolution: {integrity: sha512-WUwfFKDSOF5S9UPsNsXcLYtzjTxBGsftTXWRbZuxX6BYrsySISTnujfJNgaaQ6qVzaCDJ35QUkZKvsYxip1C5g==}
     peerDependencies:
@@ -2615,6 +3045,12 @@ packages:
 
   '@rc-component/menu@1.3.1':
     resolution: {integrity: sha512-pSZl9nBPgKgxN0aaW7NilIBEwWsc+43S+ulGdWAg9afak96dNOGWsGx0DLLBB1VQsAJvo6bQMTDzXoPlEHsBEw==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/menu@1.4.1':
+    resolution: {integrity: sha512-3GsVRoQ4cnF/AoIQ4P+Z1haBfgfBPQfLT1RJY3Nu4DzOnheTslfCiGSPj7bv/cLj5sW5pHqN25dDXGP3JELAlQ==}
     peerDependencies:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
@@ -2655,8 +3091,34 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
+  '@rc-component/pagination@1.4.0':
+    resolution: {integrity: sha512-CW1g7P9V8u+e8JQdUsl2RWg+GCsoee0mtJjZUCCxn/vb3jzOwDKm6hAdwddHCVBfWJ58eGUBZz3IvnU8rRktjw==}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
   '@rc-component/picker@1.10.0':
     resolution: {integrity: sha512-vVOXP2RVWozwpERGUFAehVH1Jz6o/uRrAb9qSZm1LC+iJs8rvEwFo1bzz2jlOYV+uWwu0dIuG86tnDui14Ea0w==}
+    engines: {node: '>=12.x'}
+    peerDependencies:
+      date-fns: '>= 2.x'
+      dayjs: '>= 1.x'
+      luxon: '>= 3.x'
+      moment: '>= 2.x'
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+    peerDependenciesMeta:
+      date-fns:
+        optional: true
+      dayjs:
+        optional: true
+      luxon:
+        optional: true
+      moment:
+        optional: true
+
+  '@rc-component/picker@1.11.0':
+    resolution: {integrity: sha512-6qXGKtoJvO8sUd17m5cyNEbEJub0zflCHnaZTBBmj63DPRZYc0WEHN8rp6hFSl+yMCJS/dJY5G+1fQ8bLCuD7A==}
     engines: {node: '>=12.x'}
     peerDependencies:
       date-fns: '>= 2.x'
@@ -2721,8 +3183,22 @@ packages:
       react: '*'
       react-dom: '*'
 
+  '@rc-component/select@1.8.2':
+    resolution: {integrity: sha512-HQ9zuYqjfZTlcEMWlU1GAPBajd2OHIMVHyjZSGVTCVARwkfCgvXZMTEn0cduy3L+ejAKkaZluOQvxovZoaJaQw==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+
   '@rc-component/slider@1.0.1':
     resolution: {integrity: sha512-uDhEPU1z3WDfCJhaL9jfd2ha/Eqpdfxsn0Zb0Xcq1NGQAman0TWaR37OWp2vVXEOdV2y0njSILTMpTfPV1454g==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
+  '@rc-component/slider@1.1.1':
+    resolution: {integrity: sha512-LSzgWGYDgeCDgR4r1XlU29gbYws6HpLnvJd/uMhLeW/vQgxldeR+Wb4uzHDCHiYEbr1bnEHWdjkPxjJRHxuiig==}
     engines: {node: '>=8.x'}
     peerDependencies:
       react: '>=16.9.0'
@@ -2748,6 +3224,13 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
+  '@rc-component/tabs@1.11.0':
+    resolution: {integrity: sha512-hA/drZYOVa/MMIb4M2fWf3yaTyTG4qVuIABmghvEhyfw2nBob5VTH69lMCDjSVKmgODjO6nWlCV+gVn3xBrj5Q==}
+    engines: {node: '>=8.x'}
+    peerDependencies:
+      react: '>=16.9.0'
+      react-dom: '>=16.9.0'
+
   '@rc-component/tabs@1.9.1':
     resolution: {integrity: sha512-6mY08Fce6aNOHuGsxbzT+f2ekgL9mg1cGGHkittMlVGymjGg+kGupu5v90sRxcUd/paRU9jclLLXtF/PkK1FUA==}
     engines: {node: '>=8.x'}
@@ -2770,6 +3253,12 @@ packages:
 
   '@rc-component/tree-select@1.10.0':
     resolution: {integrity: sha512-E1U4pn2LAbXEhLJdzIzid7WYbIuFbkTIctuFoeC6weppf8UbPR3+YYB6/ay0c0ksand4gXMRQpa1Z60Auo7VJA==}
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+
+  '@rc-component/tree-select@1.11.0':
+    resolution: {integrity: sha512-EhS0X0wtUhBfK4S5TlpSY3MR9ndPMGgujtt1PJW3Ej+ToAlnS/6ohYURtCoXBYGqazUwHmgQGVUDsfpVwhWPkg==}
     peerDependencies:
       react: '*'
       react-dom: '*'
@@ -2819,6 +3308,12 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-android-arm64@1.1.4':
+    resolution: {integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-darwin-arm64@1.0.3':
     resolution: {integrity: sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2827,6 +3322,12 @@ packages:
 
   '@rolldown/binding-darwin-arm64@1.1.1':
     resolution: {integrity: sha512-rRZRPy/Ynb+Mxu0O6tfPldHeDgAn0sRij+IOUy6sFdUlv3hArGW/DloE3GfAxtqpOJuRNgF74Nr5gM4xBeU2jQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.1.4':
+    resolution: {integrity: sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -2843,6 +3344,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-x64@1.1.4':
+    resolution: {integrity: sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
   '@rolldown/binding-freebsd-x64@1.0.3':
     resolution: {integrity: sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2851,6 +3358,12 @@ packages:
 
   '@rolldown/binding-freebsd-x64@1.1.1':
     resolution: {integrity: sha512-202K+cpIi1kx/Zn7AtxBi4LTXSY67Aszb2K9rNsuW7FeBeh0nqoNmYLOSZidV0p88VPBzMmTZcHAdPNo3kRYzQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.1.4':
+    resolution: {integrity: sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -2867,6 +3380,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
+    resolution: {integrity: sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm64-gnu@1.0.3':
     resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2876,6 +3395,13 @@ packages:
 
   '@rolldown/binding-linux-arm64-gnu@1.1.1':
     resolution: {integrity: sha512-at2EO4o7D/PJLC4Xik16bU4CcjQE2tSv1LfqMA0TRYQYQihRm3gZeDB8xaX28A9SFedibcAk5DeMCKt4REKG0A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.4':
+    resolution: {integrity: sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -2895,6 +3421,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-arm64-musl@1.1.4':
+    resolution: {integrity: sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2904,6 +3437,13 @@ packages:
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.1':
     resolution: {integrity: sha512-1WK84XPeio3tjP1sM/TMXiC0G1i1iq1qGZ71KfNQjEFLU1kwD+Cv5T8nGySg/JUFwLbaScu6ve9DmeXlmqpkFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
+    resolution: {integrity: sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -2923,6 +3463,13 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-s390x-gnu@1.1.4':
+    resolution: {integrity: sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2932,6 +3479,13 @@ packages:
 
   '@rolldown/binding-linux-x64-gnu@1.1.1':
     resolution: {integrity: sha512-NwX/wspnq4vYyMFsqbYvzums3ki/Tk8FZbMzMAovPDp3OfLeYKby/D+9osokadXuYEV3OvpeHlwnr/bG8QMixA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.4':
+    resolution: {integrity: sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -2951,6 +3505,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-x64-musl@1.1.4':
+    resolution: {integrity: sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2963,6 +3524,12 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@rolldown/binding-openharmony-arm64@1.1.4':
+    resolution: {integrity: sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@rolldown/binding-wasm32-wasi@1.0.3':
     resolution: {integrity: sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2970,6 +3537,11 @@ packages:
 
   '@rolldown/binding-wasm32-wasi@1.1.1':
     resolution: {integrity: sha512-qczfgEH8u0wHGGOXtA7UMAybNKuQjjEXairyQaw4WzjiMztfbgatG1h4OKays/smhtwbWltpKCRGtVhU6h40Sg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
+  '@rolldown/binding-wasm32-wasi@1.1.4':
+    resolution: {integrity: sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
@@ -2985,6 +3557,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@rolldown/binding-win32-arm64-msvc@1.1.4':
+    resolution: {integrity: sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@rolldown/binding-win32-x64-msvc@1.0.3':
     resolution: {integrity: sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2993,6 +3571,12 @@ packages:
 
   '@rolldown/binding-win32-x64-msvc@1.1.1':
     resolution: {integrity: sha512-MUvC/HLXVjzkQkWiExdVTEEWf0py+GfWm8WKSZsekG3ih6a21iy0BHPF07X3JIf3ifoklZXTIaHTLPBgH1C3dw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.4':
+    resolution: {integrity: sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -3220,8 +3804,17 @@ packages:
   '@tailwindcss/node@4.3.1':
     resolution: {integrity: sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==}
 
+  '@tailwindcss/node@4.3.2':
+    resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
+
   '@tailwindcss/oxide-android-arm64@4.3.1':
     resolution: {integrity: sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-android-arm64@4.3.2':
+    resolution: {integrity: sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [android]
@@ -3232,8 +3825,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@tailwindcss/oxide-darwin-arm64@4.3.2':
+    resolution: {integrity: sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@tailwindcss/oxide-darwin-x64@4.3.1':
     resolution: {integrity: sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.2':
+    resolution: {integrity: sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [darwin]
@@ -3244,14 +3849,33 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@tailwindcss/oxide-freebsd-x64@4.3.2':
+    resolution: {integrity: sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1':
     resolution: {integrity: sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==}
     engines: {node: '>= 20'}
     cpu: [arm]
     os: [linux]
 
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
+    resolution: {integrity: sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
   '@tailwindcss/oxide-linux-arm64-gnu@4.3.1':
     resolution: {integrity: sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
+    resolution: {integrity: sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
@@ -3264,6 +3888,13 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
+    resolution: {integrity: sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
     resolution: {integrity: sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==}
     engines: {node: '>= 20'}
@@ -3271,8 +3902,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
+    resolution: {integrity: sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@tailwindcss/oxide-linux-x64-musl@4.3.1':
     resolution: {integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
+    resolution: {integrity: sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
@@ -3290,8 +3935,26 @@ packages:
       - '@emnapi/wasi-threads'
       - tslib
 
+  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
+    resolution: {integrity: sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
   '@tailwindcss/oxide-win32-arm64-msvc@4.3.1':
     resolution: {integrity: sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
+    resolution: {integrity: sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [win32]
@@ -3302,12 +3965,27 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
+    resolution: {integrity: sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
   '@tailwindcss/oxide@4.3.1':
     resolution: {integrity: sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==}
     engines: {node: '>= 20'}
 
+  '@tailwindcss/oxide@4.3.2':
+    resolution: {integrity: sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==}
+    engines: {node: '>= 20'}
+
   '@tailwindcss/vite@4.3.1':
     resolution: {integrity: sha512-hItDHuIIlEV61R+faXu66s1K36aTurO/Qw0e45Vskz57gXl9pWOT6eg3zmcEui6CZXddbN7zd41bwmvag4JGwQ==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tailwindcss/vite@4.3.2':
+    resolution: {integrity: sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
@@ -3389,6 +4067,9 @@ packages:
 
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -3548,6 +4229,19 @@ packages:
 
   '@vitejs/plugin-react@6.0.2':
     resolution: {integrity: sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+
+  '@vitejs/plugin-react@6.0.3':
+    resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
@@ -3866,6 +4560,12 @@ packages:
 
   antd@6.4.4:
     resolution: {integrity: sha512-lgPz4KhfhiYddV/qPYo0ieqWimCVgV2OQF72mbeGNixE753JWNnmEc7UNGy08wBS/zZ7hxrmX0pc5aX7EUaIIg==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+
+  antd@6.5.0:
+    resolution: {integrity: sha512-9zbVc9UukfGuqCvIAov01nlpDQWfARNmZQyt21ZhqLX7ilXmi4cdkp12xA48WEmXRXwZvno8A03qQuGE9JG8fg==}
     peerDependencies:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
@@ -5782,6 +6482,10 @@ packages:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+    engines: {node: ^10 || ^12 || >=14}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -6087,6 +6791,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
+  rolldown@1.1.4:
+    resolution: {integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@4.62.0:
     resolution: {integrity: sha512-nc72Wgq62I7rtDV4izT5/aaS0zxy3kttkinf9586ApknY3jZO9NYsmtc24fUckA0X7Q2v+ML4a15pdUlV5V/jA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -6328,6 +7037,9 @@ packages:
 
   tailwindcss@4.3.1:
     resolution: {integrity: sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==}
+
+  tailwindcss@4.3.2:
+    resolution: {integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==}
 
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
@@ -6733,6 +7445,49 @@ packages:
       yaml:
         optional: true
 
+  vite@8.1.3:
+    resolution: {integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.3.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
   vitefu@1.1.3:
     resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
     peerDependencies:
@@ -6886,6 +7641,70 @@ packages:
 
 snapshots:
 
+  '@adapttable/antd@1.0.0(antd@6.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@adapttable/core': 1.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      antd: 6.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-compiler-runtime: 1.0.0(react@19.2.7)
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@adapttable/chakra@1.0.0(@chakra-ui/react@3.36.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@adapttable/core': 1.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@chakra-ui/react': 3.36.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-compiler-runtime: 1.0.0(react@19.2.7)
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@adapttable/core@1.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/react-virtual': 3.14.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-compiler-runtime: 1.0.0(react@19.2.7)
+    transitivePeerDependencies:
+      - react-dom
+
+  '@adapttable/mantine@1.0.0(@mantine/core@9.4.1(@mantine/hooks@9.4.1(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@mantine/hooks@9.4.1(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@adapttable/core': 1.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mantine/core': 9.4.1(@mantine/hooks@9.4.1(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mantine/hooks': 9.4.1(react@19.2.7)
+      react: 19.2.7
+      react-compiler-runtime: 1.0.0(react@19.2.7)
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@adapttable/mui@1.0.0(@mui/material@9.2.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@adapttable/core': 1.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mui/material': 9.2.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-compiler-runtime: 1.0.0(react@19.2.7)
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@adapttable/radix@1.0.0(@radix-ui/themes@3.3.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@adapttable/core': 1.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/themes': 3.3.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-compiler-runtime: 1.0.0(react@19.2.7)
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@adapttable/shadcn@1.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@adapttable/unstyled': 1.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-compiler-runtime: 1.0.0(react@19.2.7)
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@adapttable/unstyled@1.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@adapttable/core': 1.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-compiler-runtime: 1.0.0(react@19.2.7)
+      react-dom: 19.2.7(react@19.2.7)
+
   '@adobe/css-tools@4.5.0': {}
 
   '@ant-design/colors@8.0.1':
@@ -6916,10 +7735,21 @@ snapshots:
 
   '@ant-design/icons-svg@4.4.2': {}
 
+  '@ant-design/icons-svg@4.5.0': {}
+
   '@ant-design/icons@6.2.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@ant-design/colors': 8.0.1
       '@ant-design/icons-svg': 4.4.2
+      '@rc-component/util': 1.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@ant-design/icons@6.3.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@ant-design/colors': 8.0.1
+      '@ant-design/icons-svg': 4.5.0
       '@rc-component/util': 1.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       clsx: 2.1.1
       react: 19.2.7
@@ -7560,6 +8390,12 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
@@ -8111,7 +8947,24 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
+  '@mantine/core@9.4.1(@mantine/hooks@9.4.1(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/react': 0.27.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@mantine/hooks': 9.4.1(react@19.2.7)
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-number-format: 5.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
+      type-fest: 5.7.0
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@mantine/hooks@9.3.1(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+
+  '@mantine/hooks@9.4.1(react@19.2.7)':
     dependencies:
       react: 19.2.7
 
@@ -8163,6 +9016,8 @@ snapshots:
 
   '@mui/core-downloads-tracker@9.1.1': {}
 
+  '@mui/core-downloads-tracker@9.2.0': {}
+
   '@mui/material@9.1.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -8184,10 +9039,40 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
       '@types/react': 19.2.17
 
+  '@mui/material@9.2.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/core-downloads-tracker': 9.2.0
+      '@mui/system': 9.2.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@mui/types': 9.1.1(@types/react@19.2.17)
+      '@mui/utils': 9.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@popperjs/core': 2.11.8
+      '@types/react-transition-group': 4.4.12(@types/react@19.2.17)
+      clsx: 2.1.1
+      csstype: 3.2.3
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-is: 19.2.7
+      react-transition-group: 4.4.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@types/react': 19.2.17
+
   '@mui/private-theming@9.1.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@mui/utils': 9.1.1(@types/react@19.2.17)(react@19.2.7)
+      prop-types: 15.8.1
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@mui/private-theming@9.2.0(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/utils': 9.2.0(@types/react@19.2.17)(react@19.2.7)
       prop-types: 15.8.1
       react: 19.2.7
     optionalDependencies:
@@ -8222,6 +9107,22 @@ snapshots:
       '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
       '@types/react': 19.2.17
 
+  '@mui/system@9.2.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/private-theming': 9.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@mui/styled-engine': 9.1.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
+      '@mui/types': 9.1.1(@types/react@19.2.17)
+      '@mui/utils': 9.2.0(@types/react@19.2.17)(react@19.2.7)
+      clsx: 2.1.1
+      csstype: 3.2.3
+      prop-types: 15.8.1
+      react: 19.2.7
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@types/react': 19.2.17
+
   '@mui/types@9.1.1(@types/react@19.2.17)':
     dependencies:
       '@babel/runtime': 7.29.7
@@ -8229,6 +9130,18 @@ snapshots:
       '@types/react': 19.2.17
 
   '@mui/utils@9.1.1(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@mui/types': 9.1.1(@types/react@19.2.17)
+      '@types/prop-types': 15.7.15
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 19.2.7
+      react-is: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@mui/utils@9.2.0(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@babel/runtime': 7.29.7
       '@mui/types': 9.1.1(@types/react@19.2.17)
@@ -8254,6 +9167,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -8271,6 +9191,8 @@ snapshots:
   '@oxc-project/types@0.133.0': {}
 
   '@oxc-project/types@0.135.0': {}
+
+  '@oxc-project/types@0.138.0': {}
 
   '@pagefind/darwin-arm64@1.5.2':
     optional: true
@@ -9076,6 +9998,15 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  '@rc-component/cascader@1.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@rc-component/select': 1.8.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/tree': 1.3.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/util': 1.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@rc-component/checkbox@2.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@rc-component/util': 1.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -9103,6 +10034,15 @@ snapshots:
   '@rc-component/context@2.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@rc-component/util': 1.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@rc-component/dialog@1.10.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@rc-component/motion': 1.3.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/portal': 2.2.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/util': 1.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      clsx: 2.1.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
@@ -9140,6 +10080,14 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  '@rc-component/form@1.8.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@rc-component/async-validator': 6.0.0
+      '@rc-component/util': 1.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@rc-component/image@1.9.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@rc-component/motion': 1.3.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -9165,6 +10113,16 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  '@rc-component/mentions@1.10.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@rc-component/input': 1.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/menu': 1.4.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/trigger': 3.9.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/util': 1.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@rc-component/mentions@1.9.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@rc-component/input': 1.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -9176,6 +10134,16 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
 
   '@rc-component/menu@1.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@rc-component/motion': 1.3.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/overflow': 1.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/trigger': 3.9.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/util': 1.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@rc-component/menu@1.4.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@rc-component/motion': 1.3.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@rc-component/overflow': 1.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -9226,7 +10194,26 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  '@rc-component/pagination@1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@rc-component/util': 1.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@rc-component/picker@1.10.0(dayjs@1.11.21)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@rc-component/overflow': 1.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/resize-observer': 1.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/trigger': 3.9.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/util': 1.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      dayjs: 1.11.21
+
+  '@rc-component/picker@1.11.0(dayjs@1.11.21)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@rc-component/overflow': 1.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@rc-component/resize-observer': 1.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -9290,7 +10277,24 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  '@rc-component/select@1.8.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@rc-component/overflow': 1.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/trigger': 3.9.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/util': 1.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/virtual-list': 1.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@rc-component/slider@1.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@rc-component/util': 1.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@rc-component/slider@1.1.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@rc-component/util': 1.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       clsx: 2.1.1
@@ -9317,6 +10321,17 @@ snapshots:
       '@rc-component/resize-observer': 1.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@rc-component/util': 1.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@rc-component/virtual-list': 1.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@rc-component/tabs@1.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@rc-component/dropdown': 1.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/menu': 1.4.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/motion': 1.3.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/resize-observer': 1.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/util': 1.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       clsx: 2.1.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -9352,6 +10367,15 @@ snapshots:
   '@rc-component/tree-select@1.10.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@rc-component/select': 1.7.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/tree': 1.3.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/util': 1.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
+  '@rc-component/tree-select@1.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@rc-component/select': 1.8.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@rc-component/tree': 1.3.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@rc-component/util': 1.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       clsx: 2.1.1
@@ -9406,10 +10430,16 @@ snapshots:
   '@rolldown/binding-android-arm64@1.1.1':
     optional: true
 
+  '@rolldown/binding-android-arm64@1.1.4':
+    optional: true
+
   '@rolldown/binding-darwin-arm64@1.0.3':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.1.1':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.4':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.0.3':
@@ -9418,10 +10448,16 @@ snapshots:
   '@rolldown/binding-darwin-x64@1.1.1':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.1.4':
+    optional: true
+
   '@rolldown/binding-freebsd-x64@1.0.3':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.1.1':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.4':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.0.3':
@@ -9430,10 +10466,16 @@ snapshots:
   '@rolldown/binding-linux-arm-gnueabihf@1.1.1':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
+    optional: true
+
   '@rolldown/binding-linux-arm64-gnu@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.1.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.4':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
@@ -9442,10 +10484,16 @@ snapshots:
   '@rolldown/binding-linux-arm64-musl@1.1.1':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.1.4':
+    optional: true
+
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.1':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
@@ -9454,10 +10502,16 @@ snapshots:
   '@rolldown/binding-linux-s390x-gnu@1.1.1':
     optional: true
 
+  '@rolldown/binding-linux-s390x-gnu@1.1.4':
+    optional: true
+
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.1.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.4':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
@@ -9466,10 +10520,16 @@ snapshots:
   '@rolldown/binding-linux-x64-musl@1.1.1':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.1.4':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.0.3':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.1.1':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.4':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.0.3':
@@ -9486,10 +10546,20 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.5(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
     optional: true
 
+  '@rolldown/binding-wasm32-wasi@1.1.4':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.0.3':
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.1.1':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.1.4':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.0.3':
@@ -9498,14 +10568,27 @@ snapshots:
   '@rolldown/binding-win32-x64-msvc@1.1.1':
     optional: true
 
-  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))':
+  '@rolldown/binding-win32-x64-msvc@1.1.4':
+    optional: true
+
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))':
     dependencies:
       '@babel/core': 7.29.7
       picomatch: 4.0.4
-      rolldown: 1.1.1
+      rolldown: 1.1.4
     optionalDependencies:
       '@babel/runtime': 7.29.7
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)
+    optional: true
+
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      picomatch: 4.0.4
+      rolldown: 1.1.4
+    optionalDependencies:
+      '@babel/runtime': 7.29.7
+      vite: 8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)
 
   '@rolldown/pluginutils@1.0.1': {}
 
@@ -9662,40 +10745,86 @@ snapshots:
       source-map-js: 1.2.1
       tailwindcss: 4.3.1
 
+  '@tailwindcss/node@4.3.2':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.21.6
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.2
+
   '@tailwindcss/oxide-android-arm64@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-android-arm64@4.3.2':
     optional: true
 
   '@tailwindcss/oxide-darwin-arm64@4.3.1':
     optional: true
 
+  '@tailwindcss/oxide-darwin-arm64@4.3.2':
+    optional: true
+
   '@tailwindcss/oxide-darwin-x64@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.2':
     optional: true
 
   '@tailwindcss/oxide-freebsd-x64@4.3.1':
     optional: true
 
+  '@tailwindcss/oxide-freebsd-x64@4.3.2':
+    optional: true
+
   '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
     optional: true
 
   '@tailwindcss/oxide-linux-arm64-gnu@4.3.1':
     optional: true
 
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
+    optional: true
+
   '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
     optional: true
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
     optional: true
 
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
+    optional: true
+
   '@tailwindcss/oxide-linux-x64-musl@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
     optional: true
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.1':
     optional: true
 
+  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
+    optional: true
+
   '@tailwindcss/oxide-win32-arm64-msvc@4.3.1':
     optional: true
 
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
+    optional: true
+
   '@tailwindcss/oxide-win32-x64-msvc@4.3.1':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
     optional: true
 
   '@tailwindcss/oxide@4.3.1':
@@ -9713,12 +10842,34 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.1
 
+  '@tailwindcss/oxide@4.3.2':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.2
+      '@tailwindcss/oxide-darwin-arm64': 4.3.2
+      '@tailwindcss/oxide-darwin-x64': 4.3.2
+      '@tailwindcss/oxide-freebsd-x64': 4.3.2
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.2
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.2
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.2
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.2
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.2
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.2
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.2
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.2
+
   '@tailwindcss/vite@4.3.1(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))':
     dependencies:
       '@tailwindcss/node': 4.3.1
       '@tailwindcss/oxide': 4.3.1
       tailwindcss: 4.3.1
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)
+
+  '@tailwindcss/vite@4.3.2(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.2
+      '@tailwindcss/oxide': 4.3.2
+      tailwindcss: 4.3.2
+      vite: 8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)
 
   '@tanstack/query-core@5.101.0': {}
 
@@ -9788,6 +10939,11 @@ snapshots:
     optional: true
 
   '@tybys/wasm-util@0.10.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -9983,12 +11139,28 @@ snapshots:
 
   '@ungap/structured-clone@1.3.1': {}
 
-  '@vitejs/plugin-react@6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))':
+  '@vitejs/plugin-react@6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)
     optionalDependencies:
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
+      babel-plugin-react-compiler: 1.0.0
+
+  '@vitejs/plugin-react@6.0.2(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)
+    optionalDependencies:
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
+      babel-plugin-react-compiler: 1.0.0
+
+  '@vitejs/plugin-react@6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)
+    optionalDependencies:
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
       babel-plugin-react-compiler: 1.0.0
 
   '@vitest/coverage-v8@4.1.8(vitest@4.1.8)':
@@ -10003,7 +11175,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
+      vitest: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
 
   '@vitest/expect@4.1.8':
     dependencies:
@@ -10014,13 +11186,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))':
+  '@vitest/mocker@4.1.8(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)
+      vite: 8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -10680,6 +11852,62 @@ snapshots:
       '@rc-component/tour': 2.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@rc-component/tree': 1.3.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@rc-component/tree-select': 1.10.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/trigger': 3.9.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/upload': 1.1.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/util': 1.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      clsx: 2.1.1
+      dayjs: 1.11.21
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      scroll-into-view-if-needed: 3.1.0
+      throttle-debounce: 5.0.2
+    transitivePeerDependencies:
+      - date-fns
+      - luxon
+      - moment
+
+  antd@6.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@ant-design/colors': 8.0.1
+      '@ant-design/cssinjs': 2.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@ant-design/cssinjs-utils': 2.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@ant-design/fast-color': 3.0.1
+      '@ant-design/icons': 6.3.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@ant-design/react-slick': 2.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@babel/runtime': 7.29.7
+      '@rc-component/cascader': 1.17.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/checkbox': 2.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/collapse': 1.2.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/color-picker': 3.1.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/dialog': 1.10.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/drawer': 1.4.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/dropdown': 1.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/form': 1.8.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/image': 1.9.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/input': 1.3.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/input-number': 1.6.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/mentions': 1.10.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/menu': 1.4.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/motion': 1.3.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/mutate-observer': 2.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/notification': 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/pagination': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/picker': 1.11.0(dayjs@1.11.21)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/progress': 1.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/qrcode': 2.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/rate': 1.0.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/resize-observer': 1.1.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/segmented': 1.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/select': 1.8.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/slider': 1.1.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/steps': 1.2.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/switch': 1.0.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/table': 1.10.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/tabs': 1.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/tooltip': 1.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/tour': 2.4.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/tree': 1.3.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@rc-component/tree-select': 1.11.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@rc-component/trigger': 3.9.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@rc-component/upload': 1.1.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@rc-component/util': 1.11.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -13237,6 +14465,12 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postcss@8.5.16:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   prelude-ls@1.2.1: {}
 
   prettier@2.8.8: {}
@@ -13700,6 +14934,27 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.1
       '@rolldown/binding-win32-x64-msvc': 1.1.1
 
+  rolldown@1.1.4:
+    dependencies:
+      '@oxc-project/types': 0.138.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.4
+      '@rolldown/binding-darwin-arm64': 1.1.4
+      '@rolldown/binding-darwin-x64': 1.1.4
+      '@rolldown/binding-freebsd-x64': 1.1.4
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.4
+      '@rolldown/binding-linux-arm64-gnu': 1.1.4
+      '@rolldown/binding-linux-arm64-musl': 1.1.4
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.4
+      '@rolldown/binding-linux-s390x-gnu': 1.1.4
+      '@rolldown/binding-linux-x64-gnu': 1.1.4
+      '@rolldown/binding-linux-x64-musl': 1.1.4
+      '@rolldown/binding-openharmony-arm64': 1.1.4
+      '@rolldown/binding-wasm32-wasi': 1.1.4
+      '@rolldown/binding-win32-arm64-msvc': 1.1.4
+      '@rolldown/binding-win32-x64-msvc': 1.1.4
+
   rollup@4.62.0:
     dependencies:
       '@types/estree': 1.0.9
@@ -14062,6 +15317,8 @@ snapshots:
 
   tailwindcss@4.3.1: {}
 
+  tailwindcss@4.3.2: {}
+
   tapable@2.3.3: {}
 
   term-size@2.2.1: {}
@@ -14379,6 +15636,19 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
 
+  vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.16
+      rolldown: 1.1.4
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.9.3
+      esbuild: 0.27.7
+      fsevents: 2.3.3
+      jiti: 2.7.0
+
   vitefu@1.1.3(vite@7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)):
     optionalDependencies:
       vite: 7.3.5(@types/node@25.9.3)(jiti@2.7.0)(lightningcss@1.32.0)
@@ -14391,12 +15661,12 @@ snapshots:
       dom-accessibility-api: 0.5.16
       lodash-es: 4.18.1
       redent: 3.0.0
-      vitest: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
+      vitest: 4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
 
-  vitest@4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)):
+  vitest@4.1.8(@types/node@25.9.3)(@vitest/coverage-v8@4.1.8)(jsdom@29.1.1)(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
+      '@vitest/mocker': 4.1.8(vite@8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -14413,7 +15683,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)
+      vite: 8.1.3(@types/node@25.9.3)(esbuild@0.27.7)(jiti@2.7.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - "packages/*"
   - "apps/*"
   - "examples"
+  - "starters/*"

--- a/starters/README.md
+++ b/starters/README.md
@@ -1,0 +1,34 @@
+# AdaptTable starters
+
+One minimal [Vite](https://vite.dev) app per adapter — the kit's provider, the
+adapter's `<DataTable>`, and a single table on a demo dataset. They exist so you
+can try AdaptTable with **zero local setup**: open any one in StackBlitz and edit
+a real table in the browser.
+
+These are private workspace packages (nothing is published to npm). They are
+typechecked as part of `pnpm check`, so they can't drift from the library.
+
+## Open in StackBlitz
+
+StackBlitz opens a repo subdirectory straight from GitHub — no account needed:
+
+| Kit                 | Open                                                                                            | Source                    |
+| ------------------- | ----------------------------------------------------------------------------------------------- | ------------------------- |
+| Mantine             | [StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mantine)  | [`mantine/`](./mantine)   |
+| Material UI         | [StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/mui)      | [`mui/`](./mui)           |
+| Chakra UI           | [StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/chakra)   | [`chakra/`](./chakra)     |
+| Ant Design          | [StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/antd)     | [`antd/`](./antd)         |
+| Radix Themes        | [StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/radix)    | [`radix/`](./radix)       |
+| shadcn/ui           | [StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/shadcn)   | [`shadcn/`](./shadcn)     |
+| Unstyled / Tailwind | [StackBlitz](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/unstyled) | [`unstyled/`](./unstyled) |
+
+## Run one locally
+
+```bash
+pnpm --filter @adapttable/starter-mantine dev
+```
+
+Swap `mantine` for any kit (`mui`, `chakra`, `antd`, `radix`, `shadcn`,
+`unstyled`). Each starter depends on the **published** `@adapttable/*` packages
+(so it installs cleanly on StackBlitz); inside this monorepo pnpm links them to
+the local workspace versions.

--- a/starters/antd/index.html
+++ b/starters/antd/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AdaptTable × Ant Design — starter</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/starters/antd/package.json
+++ b/starters/antd/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@adapttable/starter-antd",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@adapttable/antd": "^1.0.0",
+    "@adapttable/core": "^1.0.0",
+    "antd": "^6.5.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.3",
+    "typescript": "^6.0.3",
+    "vite": "^8.1.3"
+  }
+}

--- a/starters/antd/src/App.tsx
+++ b/starters/antd/src/App.tsx
@@ -1,0 +1,32 @@
+import { type ColumnDef, DataTable } from "@adapttable/antd";
+
+import { type Person, people } from "./data";
+
+// Declare columns by key: headers auto-derive, cells read the key, and each
+// `filter` becomes a native kit widget with a removable chip and URL state.
+const columns: ColumnDef<Person>[] = [
+  { key: "name", sortable: true, filter: "text" },
+  { key: "role", filter: { type: "select", options: "auto" } },
+  { key: "status", filter: { type: "select", options: "auto" } },
+  {
+    key: "salary",
+    header: "Salary (USD)",
+    align: "end",
+    sortable: true,
+    accessor: (r) => r.salary.toLocaleString(),
+    sortValue: (r) => r.salary,
+    filter: "numberRange",
+  },
+  { key: "hiredAt", header: "Hired", sortable: true, filter: "dateRange" },
+];
+
+export function App() {
+  return (
+    <DataTable
+      data={people}
+      columns={columns}
+      rowKey={(r) => r.id}
+      searchPlaceholder="Search people…"
+    />
+  );
+}

--- a/starters/antd/src/data.ts
+++ b/starters/antd/src/data.ts
@@ -1,0 +1,107 @@
+export interface Person {
+  id: string;
+  name: string;
+  role: string;
+  status: "active" | "on-leave" | "retired";
+  salary: number;
+  hiredAt: string;
+}
+
+export const people: Person[] = [
+  {
+    id: "1",
+    name: "Ada Lovelace",
+    role: "Engineer",
+    status: "active",
+    salary: 96000,
+    hiredAt: "2021-03-01",
+  },
+  {
+    id: "2",
+    name: "Alan Turing",
+    role: "Founder",
+    status: "active",
+    salary: 145000,
+    hiredAt: "2019-06-15",
+  },
+  {
+    id: "3",
+    name: "Grace Hopper",
+    role: "Admiral",
+    status: "retired",
+    salary: 132000,
+    hiredAt: "2018-01-20",
+  },
+  {
+    id: "4",
+    name: "Katherine Johnson",
+    role: "Mathematician",
+    status: "active",
+    salary: 118000,
+    hiredAt: "2020-09-10",
+  },
+  {
+    id: "5",
+    name: "Edsger Dijkstra",
+    role: "Engineer",
+    status: "on-leave",
+    salary: 101000,
+    hiredAt: "2022-02-14",
+  },
+  {
+    id: "6",
+    name: "Barbara Liskov",
+    role: "Architect",
+    status: "active",
+    salary: 154000,
+    hiredAt: "2017-11-05",
+  },
+  {
+    id: "7",
+    name: "Linus Torvalds",
+    role: "Engineer",
+    status: "active",
+    salary: 128000,
+    hiredAt: "2016-04-25",
+  },
+  {
+    id: "8",
+    name: "Margaret Hamilton",
+    role: "Director",
+    status: "active",
+    salary: 162000,
+    hiredAt: "2015-07-30",
+  },
+  {
+    id: "9",
+    name: "Tim Berners-Lee",
+    role: "Founder",
+    status: "on-leave",
+    salary: 149000,
+    hiredAt: "2019-12-01",
+  },
+  {
+    id: "10",
+    name: "Radia Perlman",
+    role: "Architect",
+    status: "active",
+    salary: 141000,
+    hiredAt: "2018-08-19",
+  },
+  {
+    id: "11",
+    name: "Ken Thompson",
+    role: "Engineer",
+    status: "retired",
+    salary: 137000,
+    hiredAt: "2014-05-12",
+  },
+  {
+    id: "12",
+    name: "Frances Allen",
+    role: "Researcher",
+    status: "active",
+    salary: 123000,
+    hiredAt: "2020-01-08",
+  },
+];

--- a/starters/antd/src/main.tsx
+++ b/starters/antd/src/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App";
+
+// Ant Design works without a provider (add antd's <ConfigProvider> only when you
+// want theme or locale customization).
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/starters/antd/tsconfig.json
+++ b/starters/antd/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/starters/antd/vite.config.ts
+++ b/starters/antd/vite.config.ts
@@ -1,0 +1,7 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+// Minimal Vite config so this starter boots on StackBlitz and locally.
+export default defineConfig({
+  plugins: [react()],
+});

--- a/starters/chakra/index.html
+++ b/starters/chakra/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AdaptTable × Chakra UI — starter</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/starters/chakra/package.json
+++ b/starters/chakra/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@adapttable/starter-chakra",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@adapttable/chakra": "^1.0.0",
+    "@adapttable/core": "^1.0.0",
+    "@chakra-ui/react": "^3.36.0",
+    "@emotion/react": "^11.14.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.3",
+    "typescript": "^6.0.3",
+    "vite": "^8.1.3"
+  }
+}

--- a/starters/chakra/src/App.tsx
+++ b/starters/chakra/src/App.tsx
@@ -1,0 +1,32 @@
+import { type ColumnDef, DataTable } from "@adapttable/chakra";
+
+import { type Person, people } from "./data";
+
+// Declare columns by key: headers auto-derive, cells read the key, and each
+// `filter` becomes a native kit widget with a removable chip and URL state.
+const columns: ColumnDef<Person>[] = [
+  { key: "name", sortable: true, filter: "text" },
+  { key: "role", filter: { type: "select", options: "auto" } },
+  { key: "status", filter: { type: "select", options: "auto" } },
+  {
+    key: "salary",
+    header: "Salary (USD)",
+    align: "end",
+    sortable: true,
+    accessor: (r) => r.salary.toLocaleString(),
+    sortValue: (r) => r.salary,
+    filter: "numberRange",
+  },
+  { key: "hiredAt", header: "Hired", sortable: true, filter: "dateRange" },
+];
+
+export function App() {
+  return (
+    <DataTable
+      data={people}
+      columns={columns}
+      rowKey={(r) => r.id}
+      searchPlaceholder="Search people…"
+    />
+  );
+}

--- a/starters/chakra/src/data.ts
+++ b/starters/chakra/src/data.ts
@@ -1,0 +1,107 @@
+export interface Person {
+  id: string;
+  name: string;
+  role: string;
+  status: "active" | "on-leave" | "retired";
+  salary: number;
+  hiredAt: string;
+}
+
+export const people: Person[] = [
+  {
+    id: "1",
+    name: "Ada Lovelace",
+    role: "Engineer",
+    status: "active",
+    salary: 96000,
+    hiredAt: "2021-03-01",
+  },
+  {
+    id: "2",
+    name: "Alan Turing",
+    role: "Founder",
+    status: "active",
+    salary: 145000,
+    hiredAt: "2019-06-15",
+  },
+  {
+    id: "3",
+    name: "Grace Hopper",
+    role: "Admiral",
+    status: "retired",
+    salary: 132000,
+    hiredAt: "2018-01-20",
+  },
+  {
+    id: "4",
+    name: "Katherine Johnson",
+    role: "Mathematician",
+    status: "active",
+    salary: 118000,
+    hiredAt: "2020-09-10",
+  },
+  {
+    id: "5",
+    name: "Edsger Dijkstra",
+    role: "Engineer",
+    status: "on-leave",
+    salary: 101000,
+    hiredAt: "2022-02-14",
+  },
+  {
+    id: "6",
+    name: "Barbara Liskov",
+    role: "Architect",
+    status: "active",
+    salary: 154000,
+    hiredAt: "2017-11-05",
+  },
+  {
+    id: "7",
+    name: "Linus Torvalds",
+    role: "Engineer",
+    status: "active",
+    salary: 128000,
+    hiredAt: "2016-04-25",
+  },
+  {
+    id: "8",
+    name: "Margaret Hamilton",
+    role: "Director",
+    status: "active",
+    salary: 162000,
+    hiredAt: "2015-07-30",
+  },
+  {
+    id: "9",
+    name: "Tim Berners-Lee",
+    role: "Founder",
+    status: "on-leave",
+    salary: 149000,
+    hiredAt: "2019-12-01",
+  },
+  {
+    id: "10",
+    name: "Radia Perlman",
+    role: "Architect",
+    status: "active",
+    salary: 141000,
+    hiredAt: "2018-08-19",
+  },
+  {
+    id: "11",
+    name: "Ken Thompson",
+    role: "Engineer",
+    status: "retired",
+    salary: 137000,
+    hiredAt: "2014-05-12",
+  },
+  {
+    id: "12",
+    name: "Frances Allen",
+    role: "Researcher",
+    status: "active",
+    salary: 123000,
+    hiredAt: "2020-01-08",
+  },
+];

--- a/starters/chakra/src/main.tsx
+++ b/starters/chakra/src/main.tsx
@@ -1,0 +1,15 @@
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App";
+
+// Chakra UI v3 provider: pass a system (the built-in `defaultSystem` here, or
+// your own via `createSystem`).
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <ChakraProvider value={defaultSystem}>
+      <App />
+    </ChakraProvider>
+  </StrictMode>
+);

--- a/starters/chakra/tsconfig.json
+++ b/starters/chakra/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/starters/chakra/vite.config.ts
+++ b/starters/chakra/vite.config.ts
@@ -1,0 +1,7 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+// Minimal Vite config so this starter boots on StackBlitz and locally.
+export default defineConfig({
+  plugins: [react()],
+});

--- a/starters/mantine/index.html
+++ b/starters/mantine/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AdaptTable × Mantine — starter</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/starters/mantine/package.json
+++ b/starters/mantine/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@adapttable/starter-mantine",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@adapttable/core": "^1.0.0",
+    "@adapttable/mantine": "^1.0.0",
+    "@mantine/core": "^9.4.1",
+    "@mantine/hooks": "^9.4.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.3",
+    "typescript": "^6.0.3",
+    "vite": "^8.1.3"
+  }
+}

--- a/starters/mantine/src/App.tsx
+++ b/starters/mantine/src/App.tsx
@@ -1,0 +1,32 @@
+import { type ColumnDef, DataTable } from "@adapttable/mantine";
+
+import { type Person, people } from "./data";
+
+// Declare columns by key: headers auto-derive, cells read the key, and each
+// `filter` becomes a native kit widget with a removable chip and URL state.
+const columns: ColumnDef<Person>[] = [
+  { key: "name", sortable: true, filter: "text" },
+  { key: "role", filter: { type: "select", options: "auto" } },
+  { key: "status", filter: { type: "select", options: "auto" } },
+  {
+    key: "salary",
+    header: "Salary (USD)",
+    align: "end",
+    sortable: true,
+    accessor: (r) => r.salary.toLocaleString(),
+    sortValue: (r) => r.salary,
+    filter: "numberRange",
+  },
+  { key: "hiredAt", header: "Hired", sortable: true, filter: "dateRange" },
+];
+
+export function App() {
+  return (
+    <DataTable
+      data={people}
+      columns={columns}
+      rowKey={(r) => r.id}
+      searchPlaceholder="Search people…"
+    />
+  );
+}

--- a/starters/mantine/src/data.ts
+++ b/starters/mantine/src/data.ts
@@ -1,0 +1,107 @@
+export interface Person {
+  id: string;
+  name: string;
+  role: string;
+  status: "active" | "on-leave" | "retired";
+  salary: number;
+  hiredAt: string;
+}
+
+export const people: Person[] = [
+  {
+    id: "1",
+    name: "Ada Lovelace",
+    role: "Engineer",
+    status: "active",
+    salary: 96000,
+    hiredAt: "2021-03-01",
+  },
+  {
+    id: "2",
+    name: "Alan Turing",
+    role: "Founder",
+    status: "active",
+    salary: 145000,
+    hiredAt: "2019-06-15",
+  },
+  {
+    id: "3",
+    name: "Grace Hopper",
+    role: "Admiral",
+    status: "retired",
+    salary: 132000,
+    hiredAt: "2018-01-20",
+  },
+  {
+    id: "4",
+    name: "Katherine Johnson",
+    role: "Mathematician",
+    status: "active",
+    salary: 118000,
+    hiredAt: "2020-09-10",
+  },
+  {
+    id: "5",
+    name: "Edsger Dijkstra",
+    role: "Engineer",
+    status: "on-leave",
+    salary: 101000,
+    hiredAt: "2022-02-14",
+  },
+  {
+    id: "6",
+    name: "Barbara Liskov",
+    role: "Architect",
+    status: "active",
+    salary: 154000,
+    hiredAt: "2017-11-05",
+  },
+  {
+    id: "7",
+    name: "Linus Torvalds",
+    role: "Engineer",
+    status: "active",
+    salary: 128000,
+    hiredAt: "2016-04-25",
+  },
+  {
+    id: "8",
+    name: "Margaret Hamilton",
+    role: "Director",
+    status: "active",
+    salary: 162000,
+    hiredAt: "2015-07-30",
+  },
+  {
+    id: "9",
+    name: "Tim Berners-Lee",
+    role: "Founder",
+    status: "on-leave",
+    salary: 149000,
+    hiredAt: "2019-12-01",
+  },
+  {
+    id: "10",
+    name: "Radia Perlman",
+    role: "Architect",
+    status: "active",
+    salary: 141000,
+    hiredAt: "2018-08-19",
+  },
+  {
+    id: "11",
+    name: "Ken Thompson",
+    role: "Engineer",
+    status: "retired",
+    salary: 137000,
+    hiredAt: "2014-05-12",
+  },
+  {
+    id: "12",
+    name: "Frances Allen",
+    role: "Researcher",
+    status: "active",
+    salary: 123000,
+    hiredAt: "2020-01-08",
+  },
+];

--- a/starters/mantine/src/main.tsx
+++ b/starters/mantine/src/main.tsx
@@ -1,0 +1,17 @@
+import "@mantine/core/styles.css";
+
+import { MantineProvider } from "@mantine/core";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App";
+
+// The kit's provider is mounted once at the root, exactly as Mantine's docs
+// describe; the adapter renders through it.
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <MantineProvider>
+      <App />
+    </MantineProvider>
+  </StrictMode>
+);

--- a/starters/mantine/tsconfig.json
+++ b/starters/mantine/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/starters/mantine/vite.config.ts
+++ b/starters/mantine/vite.config.ts
@@ -1,0 +1,7 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+// Minimal Vite config so this starter boots on StackBlitz and locally.
+export default defineConfig({
+  plugins: [react()],
+});

--- a/starters/mui/index.html
+++ b/starters/mui/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AdaptTable × MUI — starter</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/starters/mui/package.json
+++ b/starters/mui/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@adapttable/starter-mui",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@adapttable/core": "^1.0.0",
+    "@adapttable/mui": "^1.0.0",
+    "@emotion/react": "^11.14.0",
+    "@emotion/styled": "^11.14.1",
+    "@mui/material": "^9.2.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.3",
+    "typescript": "^6.0.3",
+    "vite": "^8.1.3"
+  }
+}

--- a/starters/mui/src/App.tsx
+++ b/starters/mui/src/App.tsx
@@ -1,0 +1,32 @@
+import { type ColumnDef, DataTable } from "@adapttable/mui";
+
+import { type Person, people } from "./data";
+
+// Declare columns by key: headers auto-derive, cells read the key, and each
+// `filter` becomes a native kit widget with a removable chip and URL state.
+const columns: ColumnDef<Person>[] = [
+  { key: "name", sortable: true, filter: "text" },
+  { key: "role", filter: { type: "select", options: "auto" } },
+  { key: "status", filter: { type: "select", options: "auto" } },
+  {
+    key: "salary",
+    header: "Salary (USD)",
+    align: "end",
+    sortable: true,
+    accessor: (r) => r.salary.toLocaleString(),
+    sortValue: (r) => r.salary,
+    filter: "numberRange",
+  },
+  { key: "hiredAt", header: "Hired", sortable: true, filter: "dateRange" },
+];
+
+export function App() {
+  return (
+    <DataTable
+      data={people}
+      columns={columns}
+      rowKey={(r) => r.id}
+      searchPlaceholder="Search people…"
+    />
+  );
+}

--- a/starters/mui/src/data.ts
+++ b/starters/mui/src/data.ts
@@ -1,0 +1,107 @@
+export interface Person {
+  id: string;
+  name: string;
+  role: string;
+  status: "active" | "on-leave" | "retired";
+  salary: number;
+  hiredAt: string;
+}
+
+export const people: Person[] = [
+  {
+    id: "1",
+    name: "Ada Lovelace",
+    role: "Engineer",
+    status: "active",
+    salary: 96000,
+    hiredAt: "2021-03-01",
+  },
+  {
+    id: "2",
+    name: "Alan Turing",
+    role: "Founder",
+    status: "active",
+    salary: 145000,
+    hiredAt: "2019-06-15",
+  },
+  {
+    id: "3",
+    name: "Grace Hopper",
+    role: "Admiral",
+    status: "retired",
+    salary: 132000,
+    hiredAt: "2018-01-20",
+  },
+  {
+    id: "4",
+    name: "Katherine Johnson",
+    role: "Mathematician",
+    status: "active",
+    salary: 118000,
+    hiredAt: "2020-09-10",
+  },
+  {
+    id: "5",
+    name: "Edsger Dijkstra",
+    role: "Engineer",
+    status: "on-leave",
+    salary: 101000,
+    hiredAt: "2022-02-14",
+  },
+  {
+    id: "6",
+    name: "Barbara Liskov",
+    role: "Architect",
+    status: "active",
+    salary: 154000,
+    hiredAt: "2017-11-05",
+  },
+  {
+    id: "7",
+    name: "Linus Torvalds",
+    role: "Engineer",
+    status: "active",
+    salary: 128000,
+    hiredAt: "2016-04-25",
+  },
+  {
+    id: "8",
+    name: "Margaret Hamilton",
+    role: "Director",
+    status: "active",
+    salary: 162000,
+    hiredAt: "2015-07-30",
+  },
+  {
+    id: "9",
+    name: "Tim Berners-Lee",
+    role: "Founder",
+    status: "on-leave",
+    salary: 149000,
+    hiredAt: "2019-12-01",
+  },
+  {
+    id: "10",
+    name: "Radia Perlman",
+    role: "Architect",
+    status: "active",
+    salary: 141000,
+    hiredAt: "2018-08-19",
+  },
+  {
+    id: "11",
+    name: "Ken Thompson",
+    role: "Engineer",
+    status: "retired",
+    salary: 137000,
+    hiredAt: "2014-05-12",
+  },
+  {
+    id: "12",
+    name: "Frances Allen",
+    role: "Researcher",
+    status: "active",
+    salary: 123000,
+    hiredAt: "2020-01-08",
+  },
+];

--- a/starters/mui/src/main.tsx
+++ b/starters/mui/src/main.tsx
@@ -1,0 +1,15 @@
+import { createTheme, ThemeProvider } from "@mui/material";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App";
+
+// MUI works with the default theme out of the box; the ThemeProvider is here so
+// you have a place to customize it.
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <ThemeProvider theme={createTheme()}>
+      <App />
+    </ThemeProvider>
+  </StrictMode>
+);

--- a/starters/mui/tsconfig.json
+++ b/starters/mui/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/starters/mui/vite.config.ts
+++ b/starters/mui/vite.config.ts
@@ -1,0 +1,7 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+// Minimal Vite config so this starter boots on StackBlitz and locally.
+export default defineConfig({
+  plugins: [react()],
+});

--- a/starters/radix/index.html
+++ b/starters/radix/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AdaptTable × Radix Themes — starter</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/starters/radix/package.json
+++ b/starters/radix/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@adapttable/starter-radix",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@adapttable/core": "^1.0.0",
+    "@adapttable/radix": "^1.0.0",
+    "@radix-ui/themes": "^3.3.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.3",
+    "typescript": "^6.0.3",
+    "vite": "^8.1.3"
+  }
+}

--- a/starters/radix/src/App.tsx
+++ b/starters/radix/src/App.tsx
@@ -1,0 +1,32 @@
+import { type ColumnDef, DataTable } from "@adapttable/radix";
+
+import { type Person, people } from "./data";
+
+// Declare columns by key: headers auto-derive, cells read the key, and each
+// `filter` becomes a native kit widget with a removable chip and URL state.
+const columns: ColumnDef<Person>[] = [
+  { key: "name", sortable: true, filter: "text" },
+  { key: "role", filter: { type: "select", options: "auto" } },
+  { key: "status", filter: { type: "select", options: "auto" } },
+  {
+    key: "salary",
+    header: "Salary (USD)",
+    align: "end",
+    sortable: true,
+    accessor: (r) => r.salary.toLocaleString(),
+    sortValue: (r) => r.salary,
+    filter: "numberRange",
+  },
+  { key: "hiredAt", header: "Hired", sortable: true, filter: "dateRange" },
+];
+
+export function App() {
+  return (
+    <DataTable
+      data={people}
+      columns={columns}
+      rowKey={(r) => r.id}
+      searchPlaceholder="Search people…"
+    />
+  );
+}

--- a/starters/radix/src/data.ts
+++ b/starters/radix/src/data.ts
@@ -1,0 +1,107 @@
+export interface Person {
+  id: string;
+  name: string;
+  role: string;
+  status: "active" | "on-leave" | "retired";
+  salary: number;
+  hiredAt: string;
+}
+
+export const people: Person[] = [
+  {
+    id: "1",
+    name: "Ada Lovelace",
+    role: "Engineer",
+    status: "active",
+    salary: 96000,
+    hiredAt: "2021-03-01",
+  },
+  {
+    id: "2",
+    name: "Alan Turing",
+    role: "Founder",
+    status: "active",
+    salary: 145000,
+    hiredAt: "2019-06-15",
+  },
+  {
+    id: "3",
+    name: "Grace Hopper",
+    role: "Admiral",
+    status: "retired",
+    salary: 132000,
+    hiredAt: "2018-01-20",
+  },
+  {
+    id: "4",
+    name: "Katherine Johnson",
+    role: "Mathematician",
+    status: "active",
+    salary: 118000,
+    hiredAt: "2020-09-10",
+  },
+  {
+    id: "5",
+    name: "Edsger Dijkstra",
+    role: "Engineer",
+    status: "on-leave",
+    salary: 101000,
+    hiredAt: "2022-02-14",
+  },
+  {
+    id: "6",
+    name: "Barbara Liskov",
+    role: "Architect",
+    status: "active",
+    salary: 154000,
+    hiredAt: "2017-11-05",
+  },
+  {
+    id: "7",
+    name: "Linus Torvalds",
+    role: "Engineer",
+    status: "active",
+    salary: 128000,
+    hiredAt: "2016-04-25",
+  },
+  {
+    id: "8",
+    name: "Margaret Hamilton",
+    role: "Director",
+    status: "active",
+    salary: 162000,
+    hiredAt: "2015-07-30",
+  },
+  {
+    id: "9",
+    name: "Tim Berners-Lee",
+    role: "Founder",
+    status: "on-leave",
+    salary: 149000,
+    hiredAt: "2019-12-01",
+  },
+  {
+    id: "10",
+    name: "Radia Perlman",
+    role: "Architect",
+    status: "active",
+    salary: 141000,
+    hiredAt: "2018-08-19",
+  },
+  {
+    id: "11",
+    name: "Ken Thompson",
+    role: "Engineer",
+    status: "retired",
+    salary: 137000,
+    hiredAt: "2014-05-12",
+  },
+  {
+    id: "12",
+    name: "Frances Allen",
+    role: "Researcher",
+    status: "active",
+    salary: 123000,
+    hiredAt: "2020-01-08",
+  },
+];

--- a/starters/radix/src/main.tsx
+++ b/starters/radix/src/main.tsx
@@ -1,0 +1,16 @@
+import "@radix-ui/themes/styles.css";
+
+import { Theme } from "@radix-ui/themes";
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App";
+
+// Radix Themes needs its stylesheet (imported above) and a <Theme> wrapper.
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <Theme>
+      <App />
+    </Theme>
+  </StrictMode>
+);

--- a/starters/radix/tsconfig.json
+++ b/starters/radix/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/starters/radix/vite.config.ts
+++ b/starters/radix/vite.config.ts
@@ -1,0 +1,7 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+// Minimal Vite config so this starter boots on StackBlitz and locally.
+export default defineConfig({
+  plugins: [react()],
+});

--- a/starters/shadcn/index.html
+++ b/starters/shadcn/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AdaptTable × shadcn/ui — starter</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/starters/shadcn/package.json
+++ b/starters/shadcn/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@adapttable/starter-shadcn",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@adapttable/core": "^1.0.0",
+    "@adapttable/shadcn": "^1.0.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.3.2",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.3",
+    "tailwindcss": "^4.3.2",
+    "typescript": "^6.0.3",
+    "vite": "^8.1.3"
+  }
+}

--- a/starters/shadcn/src/App.tsx
+++ b/starters/shadcn/src/App.tsx
@@ -1,0 +1,32 @@
+import { type ColumnDef, DataTable } from "@adapttable/shadcn";
+
+import { type Person, people } from "./data";
+
+// Declare columns by key: headers auto-derive, cells read the key, and each
+// `filter` becomes a native kit widget with a removable chip and URL state.
+const columns: ColumnDef<Person>[] = [
+  { key: "name", sortable: true, filter: "text" },
+  { key: "role", filter: { type: "select", options: "auto" } },
+  { key: "status", filter: { type: "select", options: "auto" } },
+  {
+    key: "salary",
+    header: "Salary (USD)",
+    align: "end",
+    sortable: true,
+    accessor: (r) => r.salary.toLocaleString(),
+    sortValue: (r) => r.salary,
+    filter: "numberRange",
+  },
+  { key: "hiredAt", header: "Hired", sortable: true, filter: "dateRange" },
+];
+
+export function App() {
+  return (
+    <DataTable
+      data={people}
+      columns={columns}
+      rowKey={(r) => r.id}
+      searchPlaceholder="Search people…"
+    />
+  );
+}

--- a/starters/shadcn/src/data.ts
+++ b/starters/shadcn/src/data.ts
@@ -1,0 +1,107 @@
+export interface Person {
+  id: string;
+  name: string;
+  role: string;
+  status: "active" | "on-leave" | "retired";
+  salary: number;
+  hiredAt: string;
+}
+
+export const people: Person[] = [
+  {
+    id: "1",
+    name: "Ada Lovelace",
+    role: "Engineer",
+    status: "active",
+    salary: 96000,
+    hiredAt: "2021-03-01",
+  },
+  {
+    id: "2",
+    name: "Alan Turing",
+    role: "Founder",
+    status: "active",
+    salary: 145000,
+    hiredAt: "2019-06-15",
+  },
+  {
+    id: "3",
+    name: "Grace Hopper",
+    role: "Admiral",
+    status: "retired",
+    salary: 132000,
+    hiredAt: "2018-01-20",
+  },
+  {
+    id: "4",
+    name: "Katherine Johnson",
+    role: "Mathematician",
+    status: "active",
+    salary: 118000,
+    hiredAt: "2020-09-10",
+  },
+  {
+    id: "5",
+    name: "Edsger Dijkstra",
+    role: "Engineer",
+    status: "on-leave",
+    salary: 101000,
+    hiredAt: "2022-02-14",
+  },
+  {
+    id: "6",
+    name: "Barbara Liskov",
+    role: "Architect",
+    status: "active",
+    salary: 154000,
+    hiredAt: "2017-11-05",
+  },
+  {
+    id: "7",
+    name: "Linus Torvalds",
+    role: "Engineer",
+    status: "active",
+    salary: 128000,
+    hiredAt: "2016-04-25",
+  },
+  {
+    id: "8",
+    name: "Margaret Hamilton",
+    role: "Director",
+    status: "active",
+    salary: 162000,
+    hiredAt: "2015-07-30",
+  },
+  {
+    id: "9",
+    name: "Tim Berners-Lee",
+    role: "Founder",
+    status: "on-leave",
+    salary: 149000,
+    hiredAt: "2019-12-01",
+  },
+  {
+    id: "10",
+    name: "Radia Perlman",
+    role: "Architect",
+    status: "active",
+    salary: 141000,
+    hiredAt: "2018-08-19",
+  },
+  {
+    id: "11",
+    name: "Ken Thompson",
+    role: "Engineer",
+    status: "retired",
+    salary: 137000,
+    hiredAt: "2014-05-12",
+  },
+  {
+    id: "12",
+    name: "Frances Allen",
+    role: "Researcher",
+    status: "active",
+    salary: 123000,
+    hiredAt: "2020-01-08",
+  },
+];

--- a/starters/shadcn/src/main.tsx
+++ b/starters/shadcn/src/main.tsx
@@ -1,0 +1,14 @@
+import "./styles.css";
+
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App";
+
+// @adapttable/shadcn is the unstyled adapter pre-wired with the shadcn class
+// preset; the shadcn design tokens it references live in styles.css.
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/starters/shadcn/src/styles.css
+++ b/starters/shadcn/src/styles.css
@@ -1,0 +1,51 @@
+@import "tailwindcss";
+
+/* The shadcn class preset ships inside @adapttable/shadcn, outside this app's
+   auto-detected source roots, so scan it explicitly to compile its utilities.
+   (Every shadcn consumer adds the package to their Tailwind sources this way.) */
+@source "../node_modules/@adapttable/shadcn/dist";
+
+/* shadcn/ui "neutral" design tokens, exposed as Tailwind colors so the adapter's
+   classes (bg-card, text-muted-foreground, border, bg-primary, …) resolve. */
+@theme {
+  --color-background: hsl(0 0% 100%);
+  --color-foreground: hsl(0 0% 3.9%);
+  --color-card: hsl(0 0% 100%);
+  --color-card-foreground: hsl(0 0% 3.9%);
+  --color-muted: hsl(0 0% 96.1%);
+  --color-muted-foreground: hsl(0 0% 45.1%);
+  --color-border: hsl(0 0% 89.8%);
+  --color-input: hsl(0 0% 89.8%);
+  --color-primary: hsl(0 0% 9%);
+  --color-primary-foreground: hsl(0 0% 98%);
+  --color-accent: hsl(0 0% 96.1%);
+  --color-accent-foreground: hsl(0 0% 9%);
+  --color-ring: hsl(0 0% 63.9%);
+}
+
+/* Overriding the same vars flips the whole table to dark with no per-cell work. */
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-background: hsl(0 0% 10%);
+    --color-foreground: hsl(0 0% 95%);
+    --color-card: hsl(0 0% 12.5%);
+    --color-card-foreground: hsl(0 0% 95%);
+    --color-muted: hsl(0 0% 17%);
+    --color-muted-foreground: hsl(0 0% 64%);
+    --color-border: hsl(0 0% 22%);
+    --color-input: hsl(0 0% 26%);
+    --color-primary: hsl(0 0% 92%);
+    --color-primary-foreground: hsl(0 0% 9%);
+    --color-accent: hsl(0 0% 20%);
+    --color-accent-foreground: hsl(0 0% 98%);
+    --color-ring: hsl(0 0% 45%);
+  }
+}
+
+body {
+  margin: 0;
+  padding: 2rem;
+  background: var(--color-background);
+  color: var(--color-foreground);
+  font-family: ui-sans-serif, system-ui, sans-serif;
+}

--- a/starters/shadcn/tsconfig.json
+++ b/starters/shadcn/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/starters/shadcn/vite.config.ts
+++ b/starters/shadcn/vite.config.ts
@@ -1,0 +1,8 @@
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+// shadcn/ui is Tailwind utilities, so the Tailwind Vite plugin compiles them.
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+});

--- a/starters/unstyled/index.html
+++ b/starters/unstyled/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AdaptTable × unstyled — starter</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/starters/unstyled/package.json
+++ b/starters/unstyled/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@adapttable/starter-unstyled",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@adapttable/core": "^1.0.0",
+    "@adapttable/unstyled": "^1.0.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.3",
+    "typescript": "^6.0.3",
+    "vite": "^8.1.3"
+  }
+}

--- a/starters/unstyled/src/App.tsx
+++ b/starters/unstyled/src/App.tsx
@@ -1,0 +1,32 @@
+import { type ColumnDef, DataTable } from "@adapttable/unstyled";
+
+import { type Person, people } from "./data";
+
+// Declare columns by key: headers auto-derive, cells read the key, and each
+// `filter` becomes a native kit widget with a removable chip and URL state.
+const columns: ColumnDef<Person>[] = [
+  { key: "name", sortable: true, filter: "text" },
+  { key: "role", filter: { type: "select", options: "auto" } },
+  { key: "status", filter: { type: "select", options: "auto" } },
+  {
+    key: "salary",
+    header: "Salary (USD)",
+    align: "end",
+    sortable: true,
+    accessor: (r) => r.salary.toLocaleString(),
+    sortValue: (r) => r.salary,
+    filter: "numberRange",
+  },
+  { key: "hiredAt", header: "Hired", sortable: true, filter: "dateRange" },
+];
+
+export function App() {
+  return (
+    <DataTable
+      data={people}
+      columns={columns}
+      rowKey={(r) => r.id}
+      searchPlaceholder="Search people…"
+    />
+  );
+}

--- a/starters/unstyled/src/data.ts
+++ b/starters/unstyled/src/data.ts
@@ -1,0 +1,107 @@
+export interface Person {
+  id: string;
+  name: string;
+  role: string;
+  status: "active" | "on-leave" | "retired";
+  salary: number;
+  hiredAt: string;
+}
+
+export const people: Person[] = [
+  {
+    id: "1",
+    name: "Ada Lovelace",
+    role: "Engineer",
+    status: "active",
+    salary: 96000,
+    hiredAt: "2021-03-01",
+  },
+  {
+    id: "2",
+    name: "Alan Turing",
+    role: "Founder",
+    status: "active",
+    salary: 145000,
+    hiredAt: "2019-06-15",
+  },
+  {
+    id: "3",
+    name: "Grace Hopper",
+    role: "Admiral",
+    status: "retired",
+    salary: 132000,
+    hiredAt: "2018-01-20",
+  },
+  {
+    id: "4",
+    name: "Katherine Johnson",
+    role: "Mathematician",
+    status: "active",
+    salary: 118000,
+    hiredAt: "2020-09-10",
+  },
+  {
+    id: "5",
+    name: "Edsger Dijkstra",
+    role: "Engineer",
+    status: "on-leave",
+    salary: 101000,
+    hiredAt: "2022-02-14",
+  },
+  {
+    id: "6",
+    name: "Barbara Liskov",
+    role: "Architect",
+    status: "active",
+    salary: 154000,
+    hiredAt: "2017-11-05",
+  },
+  {
+    id: "7",
+    name: "Linus Torvalds",
+    role: "Engineer",
+    status: "active",
+    salary: 128000,
+    hiredAt: "2016-04-25",
+  },
+  {
+    id: "8",
+    name: "Margaret Hamilton",
+    role: "Director",
+    status: "active",
+    salary: 162000,
+    hiredAt: "2015-07-30",
+  },
+  {
+    id: "9",
+    name: "Tim Berners-Lee",
+    role: "Founder",
+    status: "on-leave",
+    salary: 149000,
+    hiredAt: "2019-12-01",
+  },
+  {
+    id: "10",
+    name: "Radia Perlman",
+    role: "Architect",
+    status: "active",
+    salary: 141000,
+    hiredAt: "2018-08-19",
+  },
+  {
+    id: "11",
+    name: "Ken Thompson",
+    role: "Engineer",
+    status: "retired",
+    salary: 137000,
+    hiredAt: "2014-05-12",
+  },
+  {
+    id: "12",
+    name: "Frances Allen",
+    role: "Researcher",
+    status: "active",
+    salary: 123000,
+    hiredAt: "2020-01-08",
+  },
+];

--- a/starters/unstyled/src/main.tsx
+++ b/starters/unstyled/src/main.tsx
@@ -1,0 +1,14 @@
+import "./styles.css";
+
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+
+import { App } from "./App";
+
+// The unstyled adapter renders semantic HTML with data-* hooks; styles.css
+// targets those parts. Swap it for your own CSS or Tailwind.
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/starters/unstyled/src/styles.css
+++ b/starters/unstyled/src/styles.css
@@ -1,0 +1,184 @@
+/*
+ * Minimal CSS for the unstyled adapter, targeting its `data-adapttable-part`
+ * hooks. This is a starting point — restyle or replace it with Tailwind/your
+ * own system. The adapter ships no styles of its own by design.
+ */
+:root {
+  --at-bg: #ffffff;
+  --at-fg: #1f2328;
+  --at-muted: #6b7280;
+  --at-border: #e5e7eb;
+  --at-subtle: #f9fafb;
+  --at-primary: #2563eb;
+  --at-radius: 8px;
+}
+
+body {
+  margin: 0;
+  padding: 2rem;
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  color: var(--at-fg);
+  background: var(--at-bg);
+}
+
+[data-adapttable-part="root"] {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+[data-adapttable-part="toolbar"] {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+[data-adapttable-part="search-field"],
+[data-adapttable-part="filter-input"],
+[data-adapttable-part="filter-select"],
+[data-adapttable-part="filter-operator"],
+[data-adapttable-part="rows-per-page"] {
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--at-border);
+  border-radius: var(--at-radius);
+  background: var(--at-bg);
+  color: inherit;
+  font: inherit;
+}
+
+[data-adapttable-part="filters-button"],
+[data-adapttable-part="views-button"],
+[data-adapttable-part="column-menu-button"],
+[data-adapttable-part="action-button"],
+[data-adapttable-part="page-number"],
+[data-adapttable-part="page-prev"],
+[data-adapttable-part="page-next"] {
+  padding: 0.35rem 0.6rem;
+  border: 1px solid var(--at-border);
+  border-radius: var(--at-radius);
+  background: var(--at-bg);
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+
+[data-adapttable-part="sort-button"] {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+[data-adapttable-part="table"] {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+[data-adapttable-part="header-cell"] {
+  padding: 0.5rem 0.75rem;
+  text-align: start;
+  border-bottom: 2px solid var(--at-border);
+  color: var(--at-muted);
+  font-size: 0.85rem;
+}
+
+[data-adapttable-part="cell"] {
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid var(--at-border);
+}
+
+[data-adapttable-part="row"]:hover [data-adapttable-part="cell"] {
+  background: var(--at-subtle);
+}
+
+[data-adapttable-part="chips"] {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+[data-adapttable-part="chip"] {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.2rem 0.5rem;
+  border: 1px solid var(--at-border);
+  border-radius: 999px;
+  background: var(--at-subtle);
+  font-size: 0.8rem;
+}
+
+[data-adapttable-part="chip-remove"],
+[data-adapttable-part="empty-clear"] {
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+[data-adapttable-part="filters-popover"],
+[data-adapttable-part="filters-panel"],
+[data-adapttable-part="column-menu-panel"],
+[data-adapttable-part="views-panel"] {
+  padding: 0.75rem;
+  border: 1px solid var(--at-border);
+  border-radius: var(--at-radius);
+  background: var(--at-bg);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 0.12);
+  z-index: 50;
+}
+
+[data-adapttable-part="filter-field"] {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-bottom: 0.6rem;
+}
+
+[data-adapttable-part="pager"] {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+[data-adapttable-part="page-number"][aria-current="page"] {
+  border-color: var(--at-primary);
+  background: var(--at-primary);
+  color: #ffffff;
+}
+
+[data-adapttable-part="summary-cell"] {
+  padding: 0.5rem 0.75rem;
+  border-top: 2px solid var(--at-border);
+  font-weight: 600;
+}
+
+[data-adapttable-part="empty"],
+[data-adapttable-part="loading"],
+[data-adapttable-part="error"] {
+  padding: 2rem;
+  text-align: center;
+  color: var(--at-muted);
+}
+
+[data-adapttable-part="card"] {
+  padding: 0.75rem;
+  border: 1px solid var(--at-border);
+  border-radius: var(--at-radius);
+  margin-bottom: 0.5rem;
+}
+
+[data-adapttable-part="card-row"] {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.2rem 0;
+}
+
+[data-adapttable-part="card-label"] {
+  color: var(--at-muted);
+}

--- a/starters/unstyled/tsconfig.json
+++ b/starters/unstyled/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/starters/unstyled/vite.config.ts
+++ b/starters/unstyled/vite.config.ts
@@ -1,0 +1,7 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+// Minimal Vite config so this starter boots on StackBlitz and locally.
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## What

Adds a zero-install "try it" path for AdaptTable: one minimal Vite starter per adapter, plus **Open in StackBlitz** links across the docs.

- **`starters/`** — one starter per kit (mantine, mui, chakra, antd, radix, shadcn, unstyled). Each is a real `<DataTable>` on a small demo dataset: search, sortable columns, per-column filters, pagination.
- Starters are **private workspace packages** with only `dev` + `typecheck` scripts, so they are typechecked in `pnpm check` (typecheck tasks 21 → 28) but never build or publish.
- Each pins the **published** `@adapttable/*` versions so it installs on StackBlitz from a GitHub subdirectory URL; inside the monorepo pnpm links the local workspace versions.
- **Docs:** an "Open in StackBlitz" link on every feature page (default Mantine), a "Try it in StackBlitz" section listing all kits in Getting started, a README quick-start link, and a new `starters/README.md`.

## Verification

- Full gate (`pnpm check`) green.
- Rendered locally in a browser: **Mantine, shadcn, Chakra, unstyled** (covers the component-kit, Tailwind, and plain-CSS paths, and Chakra v3's provider).
- StackBlitz boot verified on this branch (proves the published-dependency install path).

## Notes

- The doc links point at `…/tree/main/starters/…`, so they go live when this merges to `main` (same as the docs auto-deploy).
- No changeset: no `packages/*` source changed and starters are private/unpublished.

🤖 Generated with [Claude Code](https://claude.com/claude-code)