### PR TITLE
fix: keep filters popover inside the viewport on narrow screens

### DIFF
--- a/.changeset/olive-cases-repeat.md
+++ b/.changeset/olive-cases-repeat.md
@@ -1,0 +1,9 @@
+---
+"@adapttable/antd": patch
+---
+
+Keep the filters popover inside the viewport on narrow screens. The card was
+anchored to a corner placement, which antd can only flip — not slide — so on a
+phone it rendered partly off-screen with the filter controls cut off. It now
+centres under the trigger (antd slides that placement into view) and its width
+is capped to the viewport.

--- a/.changeset/plain-buttons-shave.md
+++ b/.changeset/plain-buttons-shave.md
@@ -1,0 +1,10 @@
+---
+"@adapttable/unstyled": patch
+---
+
+Keep the filters popover inside the viewport on narrow screens. The card is
+anchored to the trigger's inline edge, so on a phone it could hang past the
+screen (a 320px card under a button near the edge rendered ~170px off-screen,
+cutting off the filter controls). It now shifts back inside after opening and
+on resize, and is capped to the viewport width. `@adapttable/shadcn` inherits
+the fix.

--- a/packages/adapter-antd/src/components/FilterPopover.tsx
+++ b/packages/adapter-antd/src/components/FilterPopover.tsx
@@ -10,6 +10,10 @@ export interface FilterPopoverProps {
   activeFilterCount: number;
   onClearFilters: () => void;
   labels: Required<TableLabels>;
+  /**
+   * Accepted for a consistent adapter surface; the card centres under its
+   * trigger, so it needs no direction-specific placement.
+   */
   dir?: Direction;
   /** The Filters trigger button — becomes the popover anchor. */
   children: ReactNode;
@@ -29,7 +33,6 @@ export function FilterPopover({
   activeFilterCount,
   onClearFilters,
   labels,
-  dir = "ltr",
   children,
 }: Readonly<FilterPopoverProps>) {
   const anchorRef = useRef<HTMLSpanElement>(null);
@@ -62,7 +65,9 @@ export function FilterPopover({
   }, [open, onClose]);
 
   const content = (
-    <div style={{ minWidth: 280, maxWidth: 360 }}>
+    // The card must never claim the whole screen: antd adds its own padding
+    // around this content, so leave room for it plus a gutter on both sides.
+    <div style={{ minWidth: 280, maxWidth: "min(360px, calc(100vw - 48px))" }}>
       <Flex align="center" justify="space-between" gap="small">
         <span style={{ fontWeight: 600, fontSize: 14 }}>{labels.filters}</span>
         <Button
@@ -82,7 +87,13 @@ export function FilterPopover({
     <Popover
       open={open}
       trigger={[]}
-      placement={dir === "rtl" ? "bottomLeft" : "bottomRight"}
+      // `bottom` (not the bottomLeft/bottomRight corners): antd only grants a
+      // horizontal shift to the edge-centred placements, so a corner placement
+      // can only flip — which cannot rescue a card wider than the space beside
+      // the trigger, and left it ~80px off-screen on a phone. Centring under
+      // the trigger keeps antd's own shift-into-view behaviour, and needs no
+      // RTL variant because it is direction-agnostic.
+      placement="bottom"
       content={content}
       styles={{ content: { padding: 12 } }}
     >

--- a/packages/adapter-unstyled/src/components/FilterPopover.test.tsx
+++ b/packages/adapter-unstyled/src/components/FilterPopover.test.tsx
@@ -123,4 +123,67 @@ describe("FilterPopover", () => {
       document.querySelector('[data-adapttable-part="filters-title"]')
     ).toHaveTextContent("(3)");
   });
+
+  describe("viewport collision", () => {
+    // jsdom has no layout engine, so the card's geometry is stubbed to mirror
+    // what a real 390px phone reports: a 320px card anchored under a trigger
+    // near the right edge lands at left: -173 (measured on the live demo).
+    function stubCardRect(rect: { left: number; right: number }) {
+      const card = document.querySelector<HTMLDivElement>(
+        '[data-adapttable-part="filters-popover"]'
+      )!;
+      vi.spyOn(card, "getBoundingClientRect").mockReturnValue({
+        ...rect,
+        width: rect.right - rect.left,
+        height: 400,
+        top: 0,
+        bottom: 400,
+        x: rect.left,
+        y: 0,
+        toJSON: () => ({}),
+      });
+      return card;
+    }
+
+    it("shifts a card that overflows the left edge back into the viewport", () => {
+      vi.spyOn(document.documentElement, "clientWidth", "get").mockReturnValue(
+        390
+      );
+      renderPopover({ dir: "ltr" });
+      const card = stubCardRect({ left: -173, right: 147 });
+      // Re-open so the effect measures the stubbed geometry.
+      fireEvent.resize(window);
+      // -173 → needs +181 to clear the 8px gutter.
+      expect(card.style.transform).toBe("translateX(181px)");
+    });
+
+    it("shifts a card that overflows the right edge back into the viewport", () => {
+      vi.spyOn(document.documentElement, "clientWidth", "get").mockReturnValue(
+        390
+      );
+      renderPopover({ dir: "rtl" });
+      const card = stubCardRect({ left: 150, right: 470 });
+      fireEvent.resize(window);
+      // 470 → needs -88 to clear the 8px gutter.
+      expect(card.style.transform).toBe("translateX(-88px)");
+    });
+
+    it("leaves a card that already fits untouched", () => {
+      vi.spyOn(document.documentElement, "clientWidth", "get").mockReturnValue(
+        1280
+      );
+      renderPopover({ dir: "ltr" });
+      const card = stubCardRect({ left: 900, right: 1220 });
+      fireEvent.resize(window);
+      expect(card.style.transform).toBe("");
+    });
+
+    it("caps the card width so it can never exceed the viewport", () => {
+      renderPopover();
+      const card = document.querySelector(
+        '[data-adapttable-part="filters-popover"]'
+      )!;
+      expect(card).toHaveStyle({ maxWidth: "calc(100vw - 16px)" });
+    });
+  });
 });

--- a/packages/adapter-unstyled/src/components/FilterPopover.tsx
+++ b/packages/adapter-unstyled/src/components/FilterPopover.tsx
@@ -4,6 +4,9 @@ import { type ReactNode, useEffect, useRef } from "react";
 import { cx } from "../cx";
 import type { DataTableClassNames } from "../types";
 
+/** Breathing room kept between the popover and the viewport edge, in px. */
+const VIEWPORT_GUTTER = 8;
+
 /** Props for {@link FilterPopover}. */
 export interface FilterPopoverProps {
   open: boolean;
@@ -75,6 +78,34 @@ export function FilterPopover({
     };
   }, [open]);
 
+  // The card is anchored to the trigger's inline-start edge, so on a narrow
+  // screen it can hang past the viewport (a 320px card under a button sitting
+  // 150px from the edge lands at -170px). Kit poppers do collision detection
+  // for us; plain DOM does not, so nudge the card back inside after it mounts.
+  // Runs on open and on resize/orientation change.
+  useEffect(() => {
+    if (!open) return;
+    const card = cardRef.current;
+    if (!card) return;
+    const clampIntoViewport = () => {
+      // Measure unshifted, then re-apply, so repeat runs stay idempotent.
+      card.style.transform = "";
+      const rect = card.getBoundingClientRect();
+      const viewportWidth = document.documentElement.clientWidth;
+      let shift = 0;
+      if (rect.left < VIEWPORT_GUTTER) {
+        shift = VIEWPORT_GUTTER - rect.left;
+      } else if (rect.right > viewportWidth - VIEWPORT_GUTTER) {
+        shift = viewportWidth - VIEWPORT_GUTTER - rect.right;
+      }
+      if (shift !== 0)
+        card.style.transform = `translateX(${Math.round(shift)}px)`;
+    };
+    clampIntoViewport();
+    window.addEventListener("resize", clampIntoViewport);
+    return () => window.removeEventListener("resize", clampIntoViewport);
+  }, [open, dir]);
+
   // RTL flips which edge the card aligns to: anchor to the inline-start so it
   // stays under the button on both writing directions.
   const side = dir === "rtl" ? { left: 0 } : { right: 0 };
@@ -96,7 +127,14 @@ export function FilterPopover({
             "adapttable-filters-popover",
             classNames.filtersPopover
           )}
-          style={{ position: "absolute", top: "100%", zIndex: 200, ...side }}
+          style={{
+            position: "absolute",
+            top: "100%",
+            zIndex: 200,
+            // Shifting alone can't save a card wider than the screen.
+            maxWidth: `calc(100vw - ${VIEWPORT_GUTTER * 2}px)`,
+            ...side,
+          }}
         >
           <header
             data-adapttable-part="filters-header"


### PR DESCRIPTION
The filters popover rendered partly off-screen on phones, cutting off the filter controls. Reported against the live demo and reproduced at a 390px viewport.

## Two distinct causes

**`@adapttable/unstyled`** (and `@adapttable/shadcn`, which builds on it) anchors the card with plain CSS and had no collision handling — a 320px card under a trigger near the screen edge landed at `left: -173px`, losing more than half the card. It now shifts back inside on open and on resize, and is capped to the viewport width.

**`@adapttable/antd`** used a corner placement. antd only grants a horizontal *shift* to its edge-centred placements; a corner placement can merely *flip*, and a flip cannot rescue a card wider than the space beside the trigger — it sat ~80px off-screen. Centring under the trigger restores antd’s own slide-into-view behaviour, and is direction-agnostic so it needs no RTL variant.

Mantine, MUI, Chakra and Radix were already correct — those kits do collision detection for us.

## Verification

Measured on a 390px iPhone viewport (real touch emulation), Filters popover open:

| Adapter | Before | After |
| --- | --- | --- |
| shadcn / unstyled | `left: -173px` | `left: 8px`, fully inside |
| antd | `left: -83px`, labels clipped | fully inside (LTR **and** RTL) |
| Mantine / MUI / Chakra / Radix | already inside | unchanged |

Four unit tests cover the clamp (overflow left, overflow right, already-fits, width cap). `pnpm check` is green — no suppressions, no threshold changes.

## Release

Two `patch` changesets. All nine library packages share a fixed version group, so they move together to the next patch.