### PR TITLE
fix(docs,demo): tour poster URL + single-row kit switcher

### DIFF
--- a/apps/showcase/src/styles.css
+++ b/apps/showcase/src/styles.css
@@ -266,10 +266,14 @@ a {
 
 /* ---------- adapter switcher ---------- */
 .adapterbar {
-  display: grid;
-  grid-template-columns: repeat(7, 1fr);
+  display: flex;
+  flex-wrap: nowrap;
   gap: 8px;
   margin-bottom: 16px;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  padding-bottom: 4px; /* room for scrollbar so chips aren't clipped */
+  scrollbar-width: thin;
 }
 .adtab {
   display: flex;
@@ -283,6 +287,9 @@ a {
   background: var(--page-surface);
   transition: all 0.18s ease;
   position: relative;
+  flex: 1 0 auto;
+  min-width: 148px;
+  max-width: 200px;
 }
 .adtab:hover {
   border-color: color-mix(in oklch, var(--c) 50%, var(--page-border));
@@ -521,16 +528,18 @@ a {
 
 /* ---------- responsive ---------- */
 @media (max-width: 920px) {
-  .adapterbar {
-    grid-template-columns: repeat(2, 1fr);
-  }
   .nav__links {
     display: none;
   }
 }
 @media (max-width: 560px) {
-  .adapterbar {
-    grid-template-columns: 1fr;
+  .adtab {
+    min-width: 132px;
+    max-width: 168px;
+    padding: 10px;
+  }
+  .adtab__l small {
+    display: none; /* keep one-line scroll compact on phones */
   }
 }
 @media (prefers-reduced-motion: reduce) {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Get started with AdaptTable — React table for your UI kit
 
-<video src="https://orwa-mahmoud.github.io/adapttable/media/demo-core.mp4" poster="https://orwa-mahmoud.github.io/adapttable/media/demo-core-poster.png?v=2" controls playsinline preload="none" style="width:100%;border-radius:8px"></video>
+<video src="https://orwa-mahmoud.github.io/adapttable/media/demo-core.mp4" poster="https://orwa-mahmoud.github.io/adapttable/media/demo-core-tour.png?v=2" controls playsinline preload="none" style="width:100%;border-radius:8px"></video>
 
 AdaptTable is a headless, UI-agnostic React data table. Pick the adapter for
 your design system and you get a styled, sortable, filterable, paginated

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -7,7 +7,7 @@
 
 # Get started with AdaptTable — React table for your UI kit
 
-<video src="https://orwa-mahmoud.github.io/adapttable/media/demo-core.mp4" poster="https://orwa-mahmoud.github.io/adapttable/media/demo-core-poster.png?v=2" controls playsinline preload="none" style="width:100%;border-radius:8px"></video>
+<video src="https://orwa-mahmoud.github.io/adapttable/media/demo-core.mp4" poster="https://orwa-mahmoud.github.io/adapttable/media/demo-core-tour.png?v=2" controls playsinline preload="none" style="width:100%;border-radius:8px"></video>
 
 AdaptTable is a headless, UI-agnostic React data table. Pick the adapter for
 your design system and you get a styled, sortable, filterable, paginated


### PR DESCRIPTION
## Summary
- Point getting-started `<video poster>` at `demo-core-tour.png` (the live asset); `demo-core-poster.png` 404s and left a black player.
- Demo kit switcher: one horizontal row with overflow scroll instead of a 7-column grid that wrapped the 8th kit (Tailwind) onto a lonely second row.

## npm
**No package/changeset changes** — docs + showcase CSS only. Will not open or affect a Version Packages publish beyond what’s already pending from #69.

## Test plan
- [x] `/getting-started/` shows the tour poster before play
- [x] `/demo/` kit chips sit on one row; narrow viewport scrolls horizontally
- [x] No `.changeset` additions in this PR


Made with [Cursor](https://cursor.com)