### PR TITLE
Docs: swap the README hero video for the newer upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 **Easy by default, infinitely customizable.** One unified data source for both client-side and server-side data, URL-synced shareable state, optional virtualization, infinite-scroll & paging (auto by device), responsive mobile cards, a real filter UX, **column management** (reorder · pin · resize · show/hide), **inline cell editing**, **row grouping** with per-group aggregates, **CSV export**, first-class **i18n + RTL**, and seamless **dark mode** — out of the box.
 
 <video src="https://github.com/user-attachments/assets/3b9f8a41-a2d6-4a36-bc61-50fac3d8c3ed" poster="https://orwa-mahmoud.github.io/adapttable/media/demo-core-tour.png?v=2" controls playsinline width="860">
-  <a href="https://github.com/user-attachments/assets/3b9f8a41-a2d6-4a36-bc61-50fac3d8c3ed">▶ Watch the 25-second tour — the same data table re-rendered through Mantine, MUI, Chakra, Ant Design, Radix, Base UI, shadcn, and Tailwind, from one headless engine.</a>
+  <a href="https://github.com/user-attachments/assets/3b9f8a41-a2d6-4a36-bc61-50fac3d8c3ed">▶ Watch the tour — the same data table re-rendered through Mantine, MUI, Chakra, Ant Design, Radix, Base UI, shadcn, and Tailwind, from one headless engine.</a>
 </video>
 
 </div>

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@
 
 **Easy by default, infinitely customizable.** One unified data source for both client-side and server-side data, URL-synced shareable state, optional virtualization, infinite-scroll & paging (auto by device), responsive mobile cards, a real filter UX, **column management** (reorder · pin · resize · show/hide), **inline cell editing**, **row grouping** with per-group aggregates, **CSV export**, first-class **i18n + RTL**, and seamless **dark mode** — out of the box.
 
-<video src="https://github.com/user-attachments/assets/4dee1efd-3f19-47f4-abbd-cdccad76c4b7" poster="https://orwa-mahmoud.github.io/adapttable/media/demo-core-tour.png?v=2" controls playsinline width="860">
-  <a href="https://github.com/user-attachments/assets/4dee1efd-3f19-47f4-abbd-cdccad76c4b7">▶ Watch the 25-second tour — the same data table re-rendered through Mantine, MUI, Chakra, Ant Design, Radix, Base UI, shadcn, and Tailwind, from one headless engine.</a>
+<video src="https://github.com/user-attachments/assets/3b9f8a41-a2d6-4a36-bc61-50fac3d8c3ed" poster="https://orwa-mahmoud.github.io/adapttable/media/demo-core-tour.png?v=2" controls playsinline width="860">
+  <a href="https://github.com/user-attachments/assets/3b9f8a41-a2d6-4a36-bc61-50fac3d8c3ed">▶ Watch the 25-second tour — the same data table re-rendered through Mantine, MUI, Chakra, Ant Design, Radix, Base UI, shadcn, and Tailwind, from one headless engine.</a>
 </video>
 
 </div>


### PR DESCRIPTION
Points the hero `<video>` at the latest uploaded clip.

Both references are updated — the `src` and the fallback `<a>` inside the element — so a client that cannot play inline still links to the right file. The poster already pointed at the current frame.

README-only. The repo root is private, so nothing republishes to npm and no changeset is needed.

**Worth a look on the Files tab before merging** — GitHub renders the player there, and that is the only way to confirm an attachment plays. It cannot be checked from a terminal: attachment URLs redirect through signed S3 links that return 404 without a browser session and 403 with a token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
