### PR TITLE
Link the author name in the licence line

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ PRs welcome! See [CONTRIBUTING.md](./CONTRIBUTING.md). This is a friendly, well-
 
 ## License
 
-[MIT](./LICENSE) © Orwa Mahmoud
+[MIT](./LICENSE) © [Orwa Mahmoud](https://orwamahmoud.com)
 
 ---
 


### PR DESCRIPTION
`© Orwa Mahmoud` was already in the licence line but did not link anywhere. Now points at https://orwamahmoud.com.

One line changed, nothing else touched.