### PR TITLE
Fix two broken licence links, and link the author's site

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ PRs welcome! See [CONTRIBUTING.md](./CONTRIBUTING.md). This is a friendly, well-
 
 ## License
 
-[MIT](./LICENSE) © Orwa Mahmoud
+[MIT](./LICENSE) © [Orwa Mahmoud](https://orwamahmoud.com)
 
 ---
 

--- a/packages/adapter-antd/README.md
+++ b/packages/adapter-antd/README.md
@@ -98,4 +98,4 @@ Each clip is the real adapter, recorded on the live demo.
 
 ## License
 
-[MIT](../../LICENSE) © Orwa Mahmoud
+[MIT](../../LICENSE) © [Orwa Mahmoud](https://orwamahmoud.com)

--- a/packages/adapter-base-ui/README.md
+++ b/packages/adapter-base-ui/README.md
@@ -99,3 +99,7 @@ Each clip is the real adapter, recorded on the live demo.
 - [Live demo](https://orwa-mahmoud.github.io/adapttable/demo/)
 - [Documentation](https://orwa-mahmoud.github.io/adapttable/)
 - [StackBlitz starter](https://stackblitz.com/github/orwa-mahmoud/adapttable/tree/main/starters/base-ui)
+
+## License
+
+[MIT](../../LICENSE) © [Orwa Mahmoud](https://orwamahmoud.com)

--- a/packages/adapter-chakra/README.md
+++ b/packages/adapter-chakra/README.md
@@ -95,4 +95,4 @@ Each clip is the real adapter, recorded on the live demo.
 
 ## License
 
-[MIT](../../LICENSE) © Orwa Mahmoud
+[MIT](../../LICENSE) © [Orwa Mahmoud](https://orwamahmoud.com)

--- a/packages/adapter-mantine/README.md
+++ b/packages/adapter-mantine/README.md
@@ -107,4 +107,4 @@ Each clip is the real adapter, recorded on the live demo.
 
 ## License
 
-[MIT](../../LICENSE) © Orwa Mahmoud
+[MIT](../../LICENSE) © [Orwa Mahmoud](https://orwamahmoud.com)

--- a/packages/adapter-mui/README.md
+++ b/packages/adapter-mui/README.md
@@ -98,4 +98,4 @@ Each clip is the real adapter, recorded on the live demo.
 
 ## License
 
-[MIT](../../LICENSE) © Orwa Mahmoud
+[MIT](../../LICENSE) © [Orwa Mahmoud](https://orwamahmoud.com)

--- a/packages/adapter-radix/README.md
+++ b/packages/adapter-radix/README.md
@@ -96,4 +96,4 @@ Each clip is the real adapter, recorded on the live demo.
 
 ## License
 
-[MIT](../../LICENSE) © Orwa Mahmoud
+[MIT](../../LICENSE) © [Orwa Mahmoud](https://orwamahmoud.com)

--- a/packages/adapter-shadcn/README.md
+++ b/packages/adapter-shadcn/README.md
@@ -129,7 +129,7 @@ Each clip is the real adapter, recorded on the live demo.
 
 ## License
 
-[MIT](./LICENSE) © Orwa Mahmoud
+[MIT](../../LICENSE) © [Orwa Mahmoud](https://orwamahmoud.com)
 
 ---
 

--- a/packages/adapter-unstyled/README.md
+++ b/packages/adapter-unstyled/README.md
@@ -147,4 +147,4 @@ Each clip is the real adapter, recorded on the live demo.
 
 ## License
 
-[MIT](../../LICENSE) © Orwa Mahmoud
+[MIT](../../LICENSE) © [Orwa Mahmoud](https://orwamahmoud.com)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -89,4 +89,4 @@ What `npx @adapttable/cli init` scaffolds, running.
 
 ## License
 
-[MIT](../../LICENSE) © Orwa Mahmoud
+[MIT](../../LICENSE) © [Orwa Mahmoud](https://orwamahmoud.com)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -75,4 +75,4 @@ One dataset, re-rendered by each adapter — these clips are the cross-kit tour.
 
 ## License
 
-[MIT](../../LICENSE) © Orwa Mahmoud
+[MIT](../../LICENSE) © [Orwa Mahmoud](https://orwamahmoud.com)

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -98,4 +98,4 @@ Every clip is the same table under an Arabic locale — the whole UI mirrors, no
 
 ## License
 
-[MIT](../../LICENSE) © Orwa Mahmoud
+[MIT](../../LICENSE) © [Orwa Mahmoud](https://orwamahmoud.com)


### PR DESCRIPTION
Three README fixes, all visible on the npm package pages. No code, no new changeset — the release already queued at 1.2.3 will carry them.

## 1. `@adapttable/shadcn` had a dead licence link

Its README pointed at `./LICENSE`. npm resolves README links against `repository.directory`, so on the package page that rendered as:

```
https://github.com/orwa-mahmoud/adapttable/blob/HEAD/packages/adapter-shadcn/LICENSE  →  404
```

There is no per-package LICENSE; the only one is at the repo root. Every other package already used `../../LICENSE`, which resolves to `…/blob/HEAD/LICENSE` and works. Both confirmed by reading the rendered `href` on the live npm pages.

## 2. `@adapttable/base-ui` had no licence line at all

Its README ended at the Links section. The other ten all close with the MIT notice. Added, matching them.

## 3. The copyright name now links to the author's site

`[MIT](../../LICENSE) © [Orwa Mahmoud](https://orwamahmoud.com)` across all eleven packages and the root README.

The README is the only surface where this shows. npm's package page does **not** render the `author` field — `execa` sets `author.url` and its page has no Author section and no link to that URL anywhere; npm lists **Collaborators** instead. So `author.url` would have added a link to zero pages.

`homepage` is deliberately untouched: it means the package's home, and it correctly points at the docs site.

## Timing

Merge this **before** the Version Packages PR. The release is already queued at 1.2.3 / base-ui 1.3.3 / cli 1.1.4, so these land in the published tarballs without a new changeset.

`pnpm check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
