### PR TITLE
fix(release): skip husky hooks for the bot's version-bump commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,3 +53,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # The version-bump commit must not run the husky gate on this
+          # 2-core runner: CI enforces the same gate on every PR (including
+          # the Version Packages PR), and the full suite inside a commit
+          # hook starves past the 30s antd test budget.
+          HUSKY: "0"


### PR DESCRIPTION
The release job died before creating the Version Packages PR: the changesets action's `git commit` triggered the husky pre-commit gate on the 2-core runner, where the antd suite's heaviest test starves past its 30s budget. The hook duplicates what CI already enforces on every PR — including the Version Packages PR itself — so `HUSKY: "0"` on the action's env skips hooks for the bot's commits without weakening any gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)