### PR TITLE
chore(release): enter rc pre-mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,30 @@
+{
+  "mode": "pre",
+  "tag": "rc",
+  "initialVersions": {
+    "@adapttable/docs": "0.0.0",
+    "@adapttable/showcase": "0.0.5",
+    "@adapttable/examples": "0.0.0",
+    "@adapttable/antd": "1.2.3",
+    "@adapttable/base-ui": "1.3.3",
+    "@adapttable/chakra": "1.2.3",
+    "@adapttable/mantine": "1.2.3",
+    "@adapttable/mui": "1.2.3",
+    "@adapttable/radix": "1.2.3",
+    "@adapttable/shadcn": "1.2.3",
+    "@adapttable/unstyled": "1.2.3",
+    "@adapttable/cli": "1.1.4",
+    "@adapttable/core": "1.2.3",
+    "@adapttable/i18n": "1.2.3",
+    "@adapttable/starter-antd": "0.0.0",
+    "@adapttable/starter-base-ui": "0.0.0",
+    "@adapttable/starter-chakra": "0.0.0",
+    "@adapttable/starter-mantine": "0.0.0",
+    "@adapttable/starter-mui": "0.0.0",
+    "@adapttable/starter-radix": "0.0.0",
+    "@adapttable/starter-shadcn": "0.0.0",
+    "@adapttable/starter-unstyled": "0.0.0",
+    "@adapttable/starter-unstyled-tailwind": "0.0.0"
+  },
+  "changesets": []
+}


### PR DESCRIPTION
Puts changesets in pre-release mode with the `rc` tag: the Version Packages PR re-renders as `2.0.0-rc.1` across all eleven packages, and merging it publishes to the npm `next` dist-tag only. Exit pre-mode follows once the RC passes the fresh-clone verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)