### PR TITLE
fix(release): prettier-format what changeset version rewrites

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react:matrix": "node scripts/react-matrix.mjs",
     "peer:floors": "node scripts/peer-floors.mjs",
     "changeset": "changeset",
-    "version-packages": "changeset version",
+    "version-packages": "changeset version && prettier --write \".changeset/*.json\" \"packages/*/CHANGELOG.md\" \"packages/*/package.json\"",
     "release": "turbo run build && changeset publish",
     "publint": "pnpm --filter \"./packages/*\" exec publint --strict",
     "check": "pnpm run format:check && pnpm run lint && pnpm run lint:root && pnpm run check:readmes && pnpm run check:docsurface && pnpm run typecheck && pnpm run test:coverage && pnpm run build && pnpm run publint",


### PR DESCRIPTION
The bot's `changeset version` run rewrites `.changeset/pre.json` in changesets' own JSON style, which `format:check` then rejects on the generated branch (#90's CI). Format the version output in the `version-packages` script itself so every generated release branch passes the gate it's subject to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)