### PR TITLE
chore(ci): remote-cache wiring + docs-only light gate; demo: hide email by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,16 @@ jobs:
   verify:
     name: Format · Lint · Typecheck · Test · Build
     runs-on: ubuntu-latest
+    env:
+      # Turborepo Remote Cache (optional): with the secrets set, local green
+      # gates pre-warm CI. Absent secrets are a silent no-op.
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
     steps:
+      # Full history: the three-dot diff below needs a merge base.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
 
@@ -42,19 +50,56 @@ jobs:
           restore-keys: |
             turbo-${{ runner.os }}-
 
+      # Docs-only / workflow-only diffs skip the package gate but ALWAYS
+      # report (required checks must never sit "expected"). The doc guards
+      # and format check still run in light mode — docs edits can break
+      # check:readmes / check:docsurface. Fail-open: no diff → full gate.
+      - name: Detect relevant changes
+        id: changes
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "full=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git fetch --quiet origin "$BASE_REF"
+          if ! diff_files="$(git diff --name-only "origin/$BASE_REF"...HEAD)"; then
+            echo "Could not compute the diff — running the full gate."
+            echo "full=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if printf '%s\n' "$diff_files" \
+            | grep -qvE '^(docs/|llms.*\.txt$|README\.md$|packages/[^/]+/README\.md$|\.github/|\.changeset/|ai_docs/)'; then
+            echo "full=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "full=false" >> "$GITHUB_OUTPUT"
+            echo "Docs/workflow-only diff — running format + doc guards only."
+          fi
+
       - name: Format check
         run: pnpm format:check
 
+      - name: Check adapter READMEs advertise every feature
+        run: pnpm check:readmes
+
+      - name: Check every export is documented
+        run: pnpm check:docsurface
+
       - name: Lint
+        if: steps.changes.outputs.full == 'true'
         run: pnpm lint
 
       - name: Lint root tooling
+        if: steps.changes.outputs.full == 'true'
         run: pnpm lint:root
 
       - name: Typecheck
+        if: steps.changes.outputs.full == 'true'
         run: pnpm typecheck
 
       - name: Test with coverage
+        if: steps.changes.outputs.full == 'true'
         # One package's suite at a time: the 2-core runner can't host several
         # vitest processes at once — antd's cssinjs-heavy tests get starved
         # past the 30s per-test budget (same contention class as the local
@@ -62,9 +107,11 @@ jobs:
         run: pnpm test:coverage --concurrency=1
 
       - name: Build
+        if: steps.changes.outputs.full == 'true'
         run: pnpm build
 
       - name: Validate published package configs
+        if: steps.changes.outputs.full == 'true'
         run: pnpm publint
 
   # Every package promises `react: ^18 || ^19`, but the workspace develops on

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,6 +23,9 @@ jobs:
   e2e:
     name: Playwright smoke (showcase)
     runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
     steps:
       # Full history: the three-dot diff below needs a merge base, which a
       # shallow clone lacks (that failure once skipped the suite on a branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,9 @@ jobs:
     if: ${{ needs.guard.outputs.enabled == 'true' }}
     name: Version or Publish
     runs-on: ubuntu-latest
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
     steps:
       - uses: actions/checkout@v4
 

--- a/apps/showcase/src/Demo.tsx
+++ b/apps/showcase/src/Demo.tsx
@@ -12,6 +12,8 @@ import {
   BASE_COLUMNS,
   DEMO_FILTER_RUNTIME,
   DEMO_GROUP_AGGREGATES,
+  EDITING_DEFAULT_LAYOUT,
+  LIVE_DEFAULT_LAYOUT,
   PEOPLE,
   type Person,
 } from "./data";
@@ -181,9 +183,16 @@ export function DemoBody({
   grouping?: boolean;
   editing?: boolean;
 }>) {
+  // Demos mounted WITH editing (the /editing page) keep email visible — it
+  // is the column the walkthrough edits. Only the shared live default is
+  // swapped; explicit layouts (the wide showcase's pins) pass through.
+  const resolvedDefaultLayout =
+    editing && defaultColumnLayout === LIVE_DEFAULT_LAYOUT
+      ? EDITING_DEFAULT_LAYOUT
+      : defaultColumnLayout;
   const { layout, onLayoutChange } = useColumnLayoutUrlState({
     urlKey,
-    defaultColumnLayout,
+    defaultColumnLayout: resolvedDefaultLayout,
   });
   const onColumnLayoutChange = useCallback(
     (next: ColumnLayoutState) =>

--- a/apps/showcase/src/data.tsx
+++ b/apps/showcase/src/data.tsx
@@ -283,13 +283,21 @@ export function statusTone(
 
 /**
  * The live-demo's default column layout: `email` and `team` ship as real
- * columns but start hidden, so the table is clean by default yet has columns
- * to reveal. Revealing them (or pinning — see the showcase) widens the table
- * past its container so a pinned column visibly sticks while scrolling.
+ * columns but start hidden, so the table fits its container with no
+ * horizontal scrollbar by default. Revealing them (or pinning — see the
+ * showcase) widens the table past its container so a pinned column visibly
+ * sticks while scrolling.
  */
 export const LIVE_DEFAULT_LAYOUT: Partial<ColumnLayoutState> = {
-  // Keep email visible so the opt-in cell-editing demo is discoverable;
-  // hide team so revealing/pinning still widens past the container.
+  hidden: ["email", "team"],
+};
+
+/**
+ * The editing page's default layout: email stays visible there — it is the
+ * column its walkthrough (and e2e specs) edit — while team stays hidden so
+ * the table still fits without a horizontal scrollbar.
+ */
+export const EDITING_DEFAULT_LAYOUT: Partial<ColumnLayoutState> = {
   hidden: ["team"],
 };
 

--- a/e2e/showcase.spec.ts
+++ b/e2e/showcase.spec.ts
@@ -265,13 +265,13 @@ for (const adapter of ADAPTERS) {
       await enableToggle(page, "grouping");
       // Frontend mode ships onCellEdit; every data column is editable, so
       // scope to Barbara's row (id 6 — OUTSIDE the current page slice while
-      // grouping renders the full filtered set) and take its email cell.
-      // Guards the regression where the page-slice discard froze every
+      // grouping renders the full filtered set) and take its first editable
+      // cell. Guards the regression where the page-slice discard froze every
       // off-page row as display-only (only each group's first row edited).
       const activate = demo(page)
-        .locator("tr", { hasText: "barbara.liskov" })
+        .locator("tr", { hasText: "Barbara Liskov" })
         .locator('[data-adapttable-part="edit-cell-activate"]')
-        .nth(1);
+        .first();
       await expect(activate).toBeVisible();
       await activate.dblclick();
       // Prefer the accessible textbox — kit wrappers may put the data-* on a


### PR DESCRIPTION
Three changes, one branch (owner request):

- **Live demo:** `email`/`team` hidden by default again — no horizontal scrollbar on the GitHub Pages demo. The **/editing** page keeps email visible through its own default layout (it's the column the walkthrough and e2e specs edit); the main-page edit spec re-anchors on the visible name cell. e2e 70/70 locally.
- **Turborepo Remote Cache wiring:** `TURBO_TOKEN`/`TURBO_TEAM` env in ci/e2e/release — a silent no-op until the two secrets are added (Vercel free tier), after which local green gates pre-warm CI.
- **Docs-only light gate:** docs-/workflow-only PRs run format + `check:readmes` + `check:docsurface` (docs edits can break those) and skip the package gate — required check always reports, per e2e.yml's self-skip pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)