### PR TITLE
chore(release): exit rc pre-mode

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "rc",
   "initialVersions": {
     "@adapttable/docs": "0.0.0",


### PR DESCRIPTION
The rc verified clean from the registry (fresh install resolution, ESM/CJS and `core/adapter` entries, browser render smoke, CLI). Exiting pre-mode: the bot's next Version Packages PR carries the final `2.0.0` across all eleven packages — merging that publishes to `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)