### PR TITLE
docs: tighten the flag-contract line in the changelogs

### DIFF
--- a/docs/migrate-from-v1.md
+++ b/docs/migrate-from-v1.md
@@ -55,7 +55,7 @@ through the rename table below.
   always performs the change itself, then notifies. _Why: providing a
   logging handler used to silently replace the built-in mutation._ Take
   full control via `source.setGroupBy` / `source.clearExtras`.
-- **One source-flag contract (TanStack semantics).** `isLoading` = first
+- **One source-flag contract.** `isLoading` = first
   load only; `isFetching` = any in-flight; `hasNextPage`/`fetchNextPage` =
   infinite-append only (false / no-op when paged); `refetch` really
   re-runs. The `onQueryChange` tier now APPENDS on `fetchNextPage`

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -4713,7 +4713,7 @@ through the rename table below.
   always performs the change itself, then notifies. _Why: providing a
   logging handler used to silently replace the built-in mutation._ Take
   full control via `source.setGroupBy` / `source.clearExtras`.
-- **One source-flag contract (TanStack semantics).** `isLoading` = first
+- **One source-flag contract.** `isLoading` = first
   load only; `isFetching` = any in-flight; `hasNextPage`/`fetchNextPage` =
   infinite-append only (false / no-op when paged); `refetch` really
   re-runs. The `onQueryChange` tier now APPENDS on `fetchNextPage`

--- a/packages/adapter-antd/CHANGELOG.md
+++ b/packages/adapter-antd/CHANGELOG.md
@@ -50,7 +50,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on
@@ -183,7 +183,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on

--- a/packages/adapter-base-ui/CHANGELOG.md
+++ b/packages/adapter-base-ui/CHANGELOG.md
@@ -50,7 +50,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on
@@ -183,7 +183,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on

--- a/packages/adapter-chakra/CHANGELOG.md
+++ b/packages/adapter-chakra/CHANGELOG.md
@@ -50,7 +50,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on
@@ -183,7 +183,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on

--- a/packages/adapter-mantine/CHANGELOG.md
+++ b/packages/adapter-mantine/CHANGELOG.md
@@ -50,7 +50,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on
@@ -183,7 +183,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on

--- a/packages/adapter-mui/CHANGELOG.md
+++ b/packages/adapter-mui/CHANGELOG.md
@@ -50,7 +50,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on
@@ -183,7 +183,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on

--- a/packages/adapter-radix/CHANGELOG.md
+++ b/packages/adapter-radix/CHANGELOG.md
@@ -50,7 +50,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on
@@ -183,7 +183,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on

--- a/packages/adapter-shadcn/CHANGELOG.md
+++ b/packages/adapter-shadcn/CHANGELOG.md
@@ -50,7 +50,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on
@@ -183,7 +183,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on

--- a/packages/adapter-unstyled/CHANGELOG.md
+++ b/packages/adapter-unstyled/CHANGELOG.md
@@ -50,7 +50,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on
@@ -183,7 +183,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -50,7 +50,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on
@@ -178,7 +178,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -50,7 +50,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on
@@ -178,7 +178,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on

--- a/packages/i18n/CHANGELOG.md
+++ b/packages/i18n/CHANGELOG.md
@@ -50,7 +50,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on
@@ -183,7 +183,7 @@
     />;
     ```
 
-  - **One source-flag contract (TanStack semantics).** `isLoading` is
+  - **One source-flag contract.** `isLoading` is
     first-load only; `isFetching` is any in-flight request;
     `hasNextPage` / `fetchNextPage` are infinite-append only; `refetch`
     really re-runs. The `onQueryChange` tier now **appends** on


### PR DESCRIPTION
Tightens the flag-contract line in the changelogs and migration guide — the sentence already defines each flag explicitly, so the parenthetical was redundant. The GitHub release bodies were updated to match; npm tarballs pick up the cleaned changelog at the next patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)