### PR TITLE
Fix urlSync={false} and the self-warning table; finish the adapter-shell refactor

### DIFF
--- a/.changeset/url-adapter-honors-disabled.md
+++ b/.changeset/url-adapter-honors-disabled.md
@@ -1,0 +1,32 @@
+---
+"@adapttable/core": patch
+"@adapttable/mantine": patch
+"@adapttable/mui": patch
+"@adapttable/antd": patch
+"@adapttable/unstyled": patch
+---
+
+`urlSync={false}` now really stops URL writes, and a lone table no longer warns
+about itself.
+
+`useResolvedAdapter` resolved an explicitly passed adapter before it checked
+whether the hook was syncing, so `enabled: false` was ignored whenever a caller
+supplied an adapter. Two things followed:
+
+- A hook told not to sync still wrote through the caller's adapter — with a
+  router adapter that meant `urlSync={false}` state landing in the real address
+  bar.
+- A table mounts both data tiers on one adapter and disables the inactive one.
+  Both tiers therefore claimed the same URL namespace, and every single table
+  logged the duplicate-namespace warning about itself. No prop could silence
+  it: `urlKey` renamed both sides equally, and the warning that exists to report
+  a real two-table collision could not be told apart from the false positive.
+
+`enabled` is now checked first and beats an explicit adapter, so a disabled hook
+always resolves to its own memory store. The genuine collision — two syncing
+tables sharing a namespace — still warns.
+
+The table shells that pre-resolve a URL backend no longer forward `urlSync` to
+the tier hooks as well: the choice is already expressed by which adapter they
+resolved, and applying it twice would route the active tier to a private store
+that the saved-views menu could not read.

--- a/packages/adapter-antd/src/DataTable.tsx
+++ b/packages/adapter-antd/src/DataTable.tsx
@@ -925,7 +925,10 @@ export function DataTable<TRow>(props: Readonly<DataTableProps<TRow>>) {
     mode: props.mode,
     onQueryChange: props.onQueryChange,
     urlAdapter: resolvedUrlAdapter,
-    urlSync: props.urlSync,
+    // No `urlSync` here on purpose: the decision is already baked into WHICH
+    // adapter was resolved above (memory when off, the real one when on), and
+    // the tier hooks would otherwise apply it a second time — routing the
+    // active tier to a private store that saved views cannot see.
     urlKey: props.urlKey,
     columns: props.columns,
     filters: props.filters,

--- a/packages/adapter-mantine/src/DataTable.gaps.test.tsx
+++ b/packages/adapter-mantine/src/DataTable.gaps.test.tsx
@@ -3,12 +3,12 @@
  * rows-per-page, sort-by select, custom toolbar, searchable off) and the
  * mobile card layout (selection + row actions + confirm).
  */
+import { createMemoryAdapter, useFrontendData } from "@adapttable/core";
+import type * as AdapterModule from "@adapttable/core/adapter";
 import {
-  createMemoryAdapter,
-  useChromeBodyData,
-  useFrontendData,
-} from "@adapttable/core";
-import { type VirtualTableRow } from "@adapttable/core/adapter";
+  useDataTableShell,
+  type VirtualTableRow,
+} from "@adapttable/core/adapter";
 import { MantineProvider } from "@mantine/core";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -28,30 +28,43 @@ const columns: ColumnDef<Row>[] = [
   { key: "name", header: "Name", accessor: (r) => r.name, sortable: true },
 ];
 
-vi.mock("@adapttable/core", async (importOriginal) => {
-  const actual = await importOriginal();
-  return {
-    ...(actual as object),
-    useChromeBodyData: vi.fn(),
-  };
+vi.mock("@adapttable/core/adapter", async (importOriginal) => {
+  const actual = await importOriginal<typeof AdapterModule>();
+  return { ...actual, useDataTableShell: vi.fn(actual.useDataTableShell) };
 });
 
+const actualCore = await vi.importActual<typeof AdapterModule>(
+  "@adapttable/core/adapter"
+);
+
+/**
+ * Force a controlled virtual window by overriding the shell's `tableProps` —
+ * the body renderers read `rowEntries` exactly as they would from a real
+ * virtualizer.
+ */
+function mockBodyData(
+  rows: VirtualTableRow<Row>[],
+  top: number,
+  bottom: number
+) {
+  vi.mocked(useDataTableShell).mockImplementation((props, render) => {
+    const real = actualCore.useDataTableShell(props, render);
+    return {
+      ...real,
+      tableProps: {
+        ...real.tableProps,
+        rowEntries: rows,
+        paddingTop: top,
+        paddingBottom: bottom,
+        measureElement: vi.fn(),
+      },
+    };
+  });
+}
+
 beforeEach(() => {
-  vi.mocked(useChromeBodyData).mockImplementation((chrome, props) => ({
-    virtualization: {
-      enabled: false,
-      rows: props.source.rows.map((row, index) => ({
-        row,
-        index,
-        key: props.rowKey(row),
-      })),
-      paddingTop: 0,
-      paddingBottom: 0,
-    },
-    loadMoreRef: { current: null },
-    canLoadMore: !chrome.isPaged && !props.source.error,
-    virtualScrollRef: () => undefined,
-  }));
+  // Default: the real shell, so every non-virtual test runs untouched.
+  vi.mocked(useDataTableShell).mockImplementation(actualCore.useDataTableShell);
 });
 
 function Harness(props: {
@@ -238,24 +251,11 @@ describe("<DataTable> gaps", () => {
   });
 
   it("virtualizes desktop rows when enabled", () => {
-    vi.mocked(useChromeBodyData).mockReturnValue({
-      virtualization: {
-        enabled: true,
-        rows: [
-          {
-            row: { id: "b", name: "Bob" },
-            index: 1,
-            key: "b",
-          } satisfies VirtualTableRow<Row>,
-        ],
-        paddingTop: 48,
-        paddingBottom: 48,
-        measureElement: vi.fn(),
-      },
-      loadMoreRef: { current: null },
-      canLoadMore: true,
-      virtualScrollRef: () => undefined,
-    });
+    mockBodyData(
+      [{ row: { id: "b", name: "Bob" }, index: 1, key: "b" }],
+      48,
+      48
+    );
 
     render(
       <Harness
@@ -275,24 +275,11 @@ describe("<DataTable> gaps", () => {
   });
 
   it("virtualizes mobile cards when enabled", () => {
-    vi.mocked(useChromeBodyData).mockReturnValue({
-      virtualization: {
-        enabled: true,
-        rows: [
-          {
-            row: { id: "c", name: "Charlie" },
-            index: 2,
-            key: "c",
-          } satisfies VirtualTableRow<Row>,
-        ],
-        paddingTop: 264,
-        paddingBottom: 0,
-        measureElement: vi.fn(),
-      },
-      loadMoreRef: { current: null },
-      canLoadMore: true,
-      virtualScrollRef: () => undefined,
-    });
+    mockBodyData(
+      [{ row: { id: "c", name: "Charlie" }, index: 2, key: "c" }],
+      264,
+      0
+    );
 
     render(
       <Harness

--- a/packages/adapter-mantine/src/DataTable.tsx
+++ b/packages/adapter-mantine/src/DataTable.tsx
@@ -126,7 +126,10 @@ function useResolvedTableProps<TRow>(props: Readonly<DataTableProps<TRow>>) {
     paginationMode: props.paginationMode,
     urlKey: props.urlKey,
     urlAdapter,
-    urlSync: props.urlSync,
+    // No `urlSync` here on purpose: the decision is already baked into WHICH
+    // adapter was resolved above (memory when off, the real one when on), and
+    // the tier hooks would otherwise apply it a second time — routing the
+    // active tier to a private store that saved views cannot see.
   });
 
   // The same resolution `useTableChrome` applies — the auto form needs the

--- a/packages/adapter-mantine/src/DataTable.tsx
+++ b/packages/adapter-mantine/src/DataTable.tsx
@@ -1,22 +1,12 @@
 import {
-  ACTIONS_COLUMN_KEY,
-  type GroupCollapseState,
-  type GroupedFlatEntry,
-  isDeclarativeFilters,
-  makeExportCsvHandler,
   resolveLabels,
   type TableLabels,
-  useChromeBodyData,
-  useChromeScrollReset,
-  useFilterTriggerToggle,
   type UseSavedViewsOptions,
-  useTableChrome,
-  useTableData,
 } from "@adapttable/core";
-import { useResolvedAdapter } from "@adapttable/core/adapter";
+import { useDataTableShell } from "@adapttable/core/adapter";
 import { Box, Button, Group, Paper, Progress, Stack } from "@mantine/core";
 import { useElementSize } from "@mantine/hooks";
-import { type ReactNode, useMemo, useRef, useState } from "react";
+import { useRef } from "react";
 
 import { useMountStagger } from "./animation/useMountStagger";
 import { ActiveFilterChips } from "./components/ActiveFilterChips";
@@ -33,26 +23,6 @@ import { SavedViewsMenu } from "./components/SavedViewsMenu";
 import { TableSkeleton } from "./components/TableSkeleton";
 import { Toolbar } from "./components/Toolbar";
 import type { DataTableProps } from "./types";
-
-/** Chrome grouping bundle shape (matches `useTableChrome` / SharedTableRenderProps). */
-interface GroupingBundle<TRow> {
-  groupBy: string;
-  collapsed: GroupCollapseState;
-  entries: readonly GroupedFlatEntry<TRow>[];
-  setGroupBy: (key: string | null) => void;
-}
-
-/**
- * Prefer chrome body data's (possibly virtual-windowed) flat entries when
- * grouping is armed; otherwise leave the bundle untouched / dormant.
- */
-function withWindowedGroupingEntries<TRow>(
-  grouping: GroupingBundle<TRow> | undefined,
-  groupingEntries: readonly GroupedFlatEntry<TRow>[] | undefined
-): GroupingBundle<TRow> | undefined {
-  if (!(grouping && groupingEntries)) return grouping;
-  return { ...grouping, entries: groupingEntries };
-}
 
 const stickyToolbarStyle = (top: number) => ({
   position: "sticky" as const,
@@ -97,68 +67,6 @@ function SavedViewsSlot({
 }
 
 /**
- * Resolve the data tier (source ▸ server ▸ frontend) and the declarative
- * filter runtime into the full chrome prop set: the RESOLVED source, the
- * filters node (auto-built form for the declarative array, JSX as-is) and
- * the chip-label resolvers (derived under the caller's — the user wins
- * per key). Everything downstream consumes these.
- */
-function useResolvedTableProps<TRow>(props: Readonly<DataTableProps<TRow>>) {
-  // ONE resolved URL backend for the tier hooks AND the saved-views menu,
-  // so with `urlSync={false}` both share the same in-memory backend instead
-  // of the menu silently reading the real address bar.
-  const urlAdapter = useResolvedAdapter(
-    props.urlSync === false ? undefined : props.urlAdapter,
-    props.urlSync !== false
-  );
-  const { source, runtime } = useTableData<TRow>({
-    locale: props.locale,
-    source: props.source,
-    data: props.data,
-    total: props.total,
-    loading: props.loading,
-    error: props.error,
-    mode: props.mode,
-    onQueryChange: props.onQueryChange,
-    columns: props.columns,
-    filters: props.filters,
-    defaults: props.defaults,
-    paginationMode: props.paginationMode,
-    urlKey: props.urlKey,
-    urlAdapter,
-    // No `urlSync` here on purpose: the decision is already baked into WHICH
-    // adapter was resolved above (memory when off, the real one when on), and
-    // the tier hooks would otherwise apply it a second time — routing the
-    // active tier to a private store that saved views cannot see.
-  });
-
-  // The same resolution `useTableChrome` applies — the auto form needs the
-  // operator/value strings before the chrome exists.
-  const labels = useMemo(() => resolveLabels(props.labels), [props.labels]);
-
-  let filters: ReactNode;
-  // Column-level `filter` shorthands alone must still render the auto form —
-  // only explicit JSX takes over the drawing.
-  if (isDeclarativeFilters(props.filters) || props.filters === undefined) {
-    filters =
-      runtime.defs.length > 0 ? (
-        <AutoFilterForm defs={runtime.defs} source={source} labels={labels} />
-      ) : undefined;
-  } else {
-    filters = props.filters;
-  }
-
-  const filterLabels = useMemo(
-    () => ({ ...runtime.filterLabels, ...props.filterLabels }),
-    [runtime.filterLabels, props.filterLabels]
-  );
-
-  // `urlAdapter` is the RESOLVED backend from here on — downstream chrome
-  // (the saved-views menu) must share the table's own instance.
-  return { ...props, urlAdapter, source, filters, filterLabels };
-}
-
-/**
  * Batteries-included Mantine data table. Drop in `columns`, a `rowKey`,
  * and a data tier — raw `data` (frontend), `data` + `onQueryChange`
  * (server), or a prebuilt `source` — to get a fully styled, sortable,
@@ -168,19 +76,13 @@ function useResolvedTableProps<TRow>(props: Readonly<DataTableProps<TRow>>) {
  * @typeParam TRow - The row type.
  */
 export function DataTable<TRow>(props: Readonly<DataTableProps<TRow>>) {
-  const chromeProps = useResolvedTableProps(props);
   const {
-    rowActions,
-    searchPlaceholder,
-    sortByOptions,
     dir,
     prefetch,
-    filters,
     filtersMode = "popover",
     bulkActions,
     slots,
     classNames,
-    toolbar,
     skeletonRows,
     stickyTop = 0,
     stickyToolbar = false,
@@ -188,51 +90,49 @@ export function DataTable<TRow>(props: Readonly<DataTableProps<TRow>>) {
     stickyHeader = false,
     enableColumnMenu = false,
     savedViews,
-    exportCsv,
-  } = chromeProps;
-  const density = chromeProps.density ?? "comfortable";
+  } = props;
+  const density = props.density ?? "comfortable";
 
-  const chrome = useTableChrome<TRow>(chromeProps);
-  // Everything rendered below reads the chrome's VIEW facade — identical to
-  // `source` except under grouping, where it presents the full rendered set.
-  const viewSource = chrome.source;
-  const { table, isMobile, confirm, getRowId } = chrome;
-  // The injected actions column is first-class in the column layout: the
-  // menu lists it under `labels.actions`, hiding it strips the row actions
-  // HERE — before any renderer sees them — so the column, its pin lead and
-  // the spacer/detail spans all disappear together, and pinning it sticks
-  // the column to the inline end without involving any data column.
-  const hasRowActions = (rowActions?.length ?? 0) > 0;
-  const visibleRowActions = chrome.columnLayout.isHidden(ACTIONS_COLUMN_KEY)
-    ? undefined
-    : rowActions;
-  const actionsPinned =
-    chrome.columnLayout.state.pinned[ACTIONS_COLUMN_KEY] === "end";
+  // The whole shared orchestration — data tier, filter runtime, chrome,
+  // scroll reset, body windowing — lives in core. Mantine adds only what its
+  // kit needs: a measured sticky toolbar, per-body stagger refs, and density.
+  const shell = useDataTableShell<TRow>(props, (defs, source) => (
+    <AutoFilterForm
+      defs={defs}
+      source={source}
+      labels={resolveLabels(props.labels)}
+    />
+  ));
   const {
-    virtualization,
-    groupingEntries,
+    chrome,
+    table,
+    filtersNode: filters,
+    filtersOpen: drawerOpened,
+    setFiltersOpen: setDrawerOpened,
+    filtersTrigger,
+    rootRef,
     loadMoreRef,
     canLoadMore,
-    virtualScrollRef,
-  } = useChromeBodyData(chrome, chromeProps);
-  const grouping = withWindowedGroupingEntries(
-    chrome.grouping,
-    groupingEntries
-  );
-  const [drawerOpened, setDrawerOpened] = useState(false);
-  const filtersTrigger = useFilterTriggerToggle(drawerOpened, setDrawerOpened);
-  const rootRef = useRef<HTMLDivElement>(null);
+    hasRowActions,
+    toolbarProps,
+  } = shell;
+  // Everything rendered below reads the chrome's VIEW facade — identical to
+  // the raw source except under grouping, where it presents the full set.
+  const viewSource = shell.source;
+  const { isMobile, confirm } = chrome;
   const { ref: toolbarRef, height: toolbarHeight } = useElementSize();
 
   const desktopBodyRef = useRef<HTMLTableSectionElement>(null);
   const mobileBodyRef = useRef<HTMLDivElement>(null);
-  useChromeScrollReset(rootRef, chrome, chromeProps);
 
   useMountStagger(
     isMobile ? mobileBodyRef : desktopBodyRef,
-    [virtualization.rows.length, isMobile],
+    [shell.tableProps.rows.length, isMobile],
     { enabled: animate }
   );
+
+  // Kit-agnostic render bundle + Mantine's own extras.
+  const tableProps = { ...shell.tableProps, density };
 
   let body: React.ReactNode;
   if (chrome.body === "skeleton") {
@@ -263,65 +163,24 @@ export function DataTable<TRow>(props: Readonly<DataTableProps<TRow>>) {
   } else if (chrome.body === "mobile") {
     body = (
       <MobileCards
-        table={table}
-        rows={chrome.editingRows}
-        rowActions={visibleRowActions}
-        confirm={confirm}
-        getRowId={getRowId}
-        onRowClick={props.onRowClick}
-        rowClassName={props.rowClassName}
-        renderRowDetail={props.renderRowDetail}
-        summaryRow={props.summaryRow}
-        expansion={chrome.detail?.expansion}
-        editing={chrome.editing}
-        grouping={grouping}
+        {...tableProps}
         bodyRef={mobileBodyRef}
         className={classNames?.card}
-        rowEntries={virtualization.enabled ? virtualization.rows : undefined}
-        paddingTop={virtualization.paddingTop}
-        paddingBottom={virtualization.paddingBottom}
-        measureElement={virtualization.measureElement}
-        density={density}
       />
     );
   } else {
     body = (
       <DesktopTable
-        table={table}
-        rows={chrome.editingRows}
-        rowActions={visibleRowActions}
-        confirm={confirm}
+        {...tableProps}
         prefetch={prefetch}
-        onRowClick={props.onRowClick}
-        rowClassName={props.rowClassName}
-        renderRowDetail={props.renderRowDetail}
-        summaryRow={props.summaryRow}
-        expansion={chrome.detail?.expansion}
-        editing={chrome.editing}
-        grouping={grouping}
-        getRowId={getRowId}
         bodyRef={desktopBodyRef}
         className={classNames?.table}
-        rowEntries={virtualization.enabled ? virtualization.rows : undefined}
-        paddingTop={virtualization.paddingTop}
-        paddingBottom={virtualization.paddingBottom}
-        measureElement={virtualization.measureElement}
+        stickyHeader={stickyHeader}
         stickyHeaderOffset={stickyHeaderInset(
           stickyToolbar,
           stickyTop,
           toolbarHeight
         )}
-        stickyHeader={stickyHeader}
-        pinOffset={chrome.columnLayout.pinOffset}
-        actionsPinned={actionsPinned}
-        maxHeight={props.maxHeight}
-        virtualScrollRef={virtualScrollRef}
-        setWidth={
-          props.resizableColumns ? chrome.columnLayout.setWidth : undefined
-        }
-        columnWidths={chrome.columnLayout.state.widths}
-        resizeLabel={table.labels.resizeColumn}
-        density={density}
       />
     );
   }
@@ -344,29 +203,20 @@ export function DataTable<TRow>(props: Readonly<DataTableProps<TRow>>) {
         >
           <Stack gap="xs">
             <Toolbar
-              table={table}
-              searchable={chromeProps.searchable !== false}
-              searchPlaceholder={searchPlaceholder}
-              sortByOptions={sortByOptions}
-              toolbar={toolbar}
-              hasFilters={Boolean(filters)}
-              activeFilterCount={chrome.activeFilterCount}
+              {...toolbarProps}
               filtersMode={filtersMode}
-              filters={filters}
               filtersOpen={drawerOpened}
               onToggleFilters={filtersTrigger.onClick}
               onFiltersTriggerPointerDown={filtersTrigger.onPointerDown}
               onCloseFilters={() => setDrawerOpened(false)}
-              onClearFilters={chrome.clearFilters}
-              dir={dir}
               savedViewsMenu={
                 savedViews && (
                   <SavedViewsSlot
                     // The table's own URL backend/namespace are the
                     // defaults — an explicit option still wins.
                     options={{
-                      urlAdapter: chromeProps.urlAdapter,
-                      urlKey: chromeProps.urlKey,
+                      urlAdapter: shell.urlAdapter,
+                      urlKey: props.urlKey,
                       ...savedViews,
                     }}
                     labels={table.labels}
@@ -383,12 +233,6 @@ export function DataTable<TRow>(props: Readonly<DataTableProps<TRow>>) {
                   dir={dir}
                 />
               }
-              onExportCsv={makeExportCsvHandler(
-                exportCsv,
-                viewSource,
-                chrome.columnLayout.visibleColumns
-              )}
-              showRowsPerPage={canLoadMore && !chrome.grouping}
             />
             <ActiveFilterChips
               chips={chrome.mergedChips}

--- a/packages/adapter-mantine/src/mobile-virtual-padding.test.tsx
+++ b/packages/adapter-mantine/src/mobile-virtual-padding.test.tsx
@@ -1,13 +1,11 @@
 /**
  * Covers MobileCards' trailing virtual-spacer branch (`paddingBottom > 0`).
- * We mock `useChromeBodyData` to return a non-zero `paddingBottom`, which
- * is only rendered in the virtualized mobile layout.
+ * The shell's `tableProps` are overridden with a non-zero `paddingBottom`,
+ * which is only rendered in the virtualized mobile layout.
  */
-import {
-  createMemoryAdapter,
-  useChromeBodyData,
-  useFrontendData,
-} from "@adapttable/core";
+import { createMemoryAdapter, useFrontendData } from "@adapttable/core";
+import type * as AdapterModule from "@adapttable/core/adapter";
+import { useDataTableShell } from "@adapttable/core/adapter";
 import { MantineProvider } from "@mantine/core";
 import { render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -27,31 +25,33 @@ const columns: ColumnDef<Row>[] = [
   { key: "name", header: "Name", accessor: (r) => r.name },
 ];
 
-vi.mock("@adapttable/core", async (importOriginal) => {
-  const actual = await importOriginal();
-  return {
-    ...(actual as object),
-    useChromeBodyData: vi.fn(),
-  };
+vi.mock("@adapttable/core/adapter", async (importOriginal) => {
+  const actual = await importOriginal<typeof AdapterModule>();
+  return { ...actual, useDataTableShell: vi.fn(actual.useDataTableShell) };
 });
 
+const actualCore = await vi.importActual<typeof AdapterModule>(
+  "@adapttable/core/adapter"
+);
+
 beforeEach(() => {
-  vi.mocked(useChromeBodyData).mockImplementation((_chrome, props) => ({
-    virtualization: {
-      enabled: true,
-      rows: props.source.rows.map((row, index) => ({
-        row,
-        index,
-        key: props.rowKey(row),
-      })),
-      paddingTop: 0,
-      // Non-zero trailing padding renders the bottom spacer div.
-      paddingBottom: 40,
-    },
-    loadMoreRef: { current: null },
-    canLoadMore: true,
-    virtualScrollRef: () => undefined,
-  }));
+  vi.mocked(useDataTableShell).mockImplementation((props, render) => {
+    const real = actualCore.useDataTableShell(props, render);
+    return {
+      ...real,
+      tableProps: {
+        ...real.tableProps,
+        rowEntries: real.tableProps.rows.map((row, index) => ({
+          row,
+          index,
+          key: String(real.tableProps.getRowId(row)),
+        })),
+        paddingTop: 0,
+        // Non-zero trailing padding renders the bottom spacer div.
+        paddingBottom: 40,
+      },
+    };
+  });
 });
 
 const adapter = createMemoryAdapter("");

--- a/packages/adapter-mui/src/DataTable.coverage.test.tsx
+++ b/packages/adapter-mui/src/DataTable.coverage.test.tsx
@@ -1,10 +1,5 @@
 /** Coverage gap-fill: drawer close, footer limit, page label, virtual rows, row select. */
-import type * as AdaptTableCore from "@adapttable/core";
-import {
-  createMemoryAdapter,
-  useChromeBodyData,
-  useFrontendData,
-} from "@adapttable/core";
+import { createMemoryAdapter, useFrontendData } from "@adapttable/core";
 import { createTheme, ThemeProvider } from "@mui/material";
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -27,20 +22,52 @@ const columns: ColumnDef<Row>[] = [
 ];
 const theme = createTheme();
 
-vi.mock("@adapttable/core", async (importOriginal) => {
-  const actual = await importOriginal();
-  return {
-    ...(actual as object),
-    useChromeBodyData: vi.fn(),
-  };
+import type * as AdapterModule from "@adapttable/core/adapter";
+import {
+  useDataTableShell,
+  type VirtualTableRow,
+} from "@adapttable/core/adapter";
+
+vi.mock("@adapttable/core/adapter", async (importOriginal) => {
+  const actual = await importOriginal<typeof AdapterModule>();
+  return { ...actual, useDataTableShell: vi.fn(actual.useDataTableShell) };
 });
+
+const actualAdapter = await vi.importActual<typeof AdapterModule>(
+  "@adapttable/core/adapter"
+);
+
+/**
+ * Force a controlled virtual window by overriding the shell's `tableProps` —
+ * the body renderers read `rowEntries` exactly as from a real virtualizer.
+ */
+function mockBodyData(
+  rows: VirtualTableRow<Row>[],
+  top: number,
+  bottom: number
+) {
+  vi.mocked(useDataTableShell).mockImplementation((props, render) => {
+    const real = actualAdapter.useDataTableShell(props, render);
+    return {
+      ...real,
+      tableProps: {
+        ...real.tableProps,
+        rowEntries: rows,
+        paddingTop: top,
+        paddingBottom: bottom,
+        measureElement: vi.fn(),
+      },
+    };
+  });
+}
 
 let adapter: ReturnType<typeof createMemoryAdapter>;
 
-beforeEach(async () => {
-  const actual =
-    await vi.importActual<typeof AdaptTableCore>("@adapttable/core");
-  vi.mocked(useChromeBodyData).mockImplementation(actual.useChromeBodyData);
+beforeEach(() => {
+  // Default: the real shell, so non-virtual tests run untouched.
+  vi.mocked(useDataTableShell).mockImplementation(
+    actualAdapter.useDataTableShell
+  );
 });
 
 function mount(
@@ -378,18 +405,7 @@ describe("MUI coverage gaps", () => {
   it("virtualizes mobile cards with a trailing bottom-pad spacer", () => {
     // paddingBottom > 0 → the trailing `paddingBottom > 0 &&` spacer renders
     // (MobileCards true branch). paddingTop is 0 so only the bottom spacer.
-    vi.mocked(useChromeBodyData).mockReturnValue({
-      virtualization: {
-        enabled: true,
-        rows: [{ row: ROWS[1]!, index: 1, key: "b" }],
-        paddingTop: 0,
-        paddingBottom: 80,
-        measureElement: vi.fn(),
-      },
-      loadMoreRef: { current: null },
-      canLoadMore: true,
-      virtualScrollRef: () => undefined,
-    });
+    mockBodyData([{ row: ROWS[1]!, index: 1, key: "b" }], 0, 80);
     mount({ forceMobile: true, virtualize: true }, "infinite");
     const list = screen.getByRole("list");
     expect(within(list).getByText("Bob")).toBeInTheDocument();

--- a/packages/adapter-mui/src/DataTable.gaps.test.tsx
+++ b/packages/adapter-mui/src/DataTable.gaps.test.tsx
@@ -1,11 +1,10 @@
 /** Gap-fill: MUI select onChange handlers and chip delete. */
-import type * as AdaptTableCore from "@adapttable/core";
+import { createMemoryAdapter, useFrontendData } from "@adapttable/core";
+import type * as AdapterModule from "@adapttable/core/adapter";
 import {
-  createMemoryAdapter,
-  useChromeBodyData,
-  useFrontendData,
-} from "@adapttable/core";
-import { type VirtualTableRow } from "@adapttable/core/adapter";
+  useDataTableShell,
+  type VirtualTableRow,
+} from "@adapttable/core/adapter";
 import { createTheme, ThemeProvider } from "@mui/material";
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -26,20 +25,46 @@ const columns: ColumnDef<Row>[] = [
 ];
 const theme = createTheme();
 
-vi.mock("@adapttable/core", async (importOriginal) => {
-  const actual = await importOriginal();
-  return {
-    ...(actual as object),
-    useChromeBodyData: vi.fn(),
-  };
+vi.mock("@adapttable/core/adapter", async (importOriginal) => {
+  const actual = await importOriginal<typeof AdapterModule>();
+  return { ...actual, useDataTableShell: vi.fn(actual.useDataTableShell) };
 });
+
+const actualAdapter = await vi.importActual<typeof AdapterModule>(
+  "@adapttable/core/adapter"
+);
+
+/**
+ * Force a controlled virtual window by overriding the shell's `tableProps` —
+ * the body renderers read `rowEntries` exactly as from a real virtualizer.
+ */
+function mockBodyData(
+  rows: VirtualTableRow<Row>[],
+  top: number,
+  bottom: number
+) {
+  vi.mocked(useDataTableShell).mockImplementation((props, render) => {
+    const real = actualAdapter.useDataTableShell(props, render);
+    return {
+      ...real,
+      tableProps: {
+        ...real.tableProps,
+        rowEntries: rows,
+        paddingTop: top,
+        paddingBottom: bottom,
+        measureElement: vi.fn(),
+      },
+    };
+  });
+}
 
 let adapter: ReturnType<typeof createMemoryAdapter>;
 
-beforeEach(async () => {
-  const actual =
-    await vi.importActual<typeof AdaptTableCore>("@adapttable/core");
-  vi.mocked(useChromeBodyData).mockImplementation(actual.useChromeBodyData);
+beforeEach(() => {
+  // Default: the real shell, so non-virtual tests run untouched.
+  vi.mocked(useDataTableShell).mockImplementation(
+    actualAdapter.useDataTableShell
+  );
 });
 
 function mount(
@@ -150,48 +175,22 @@ describe("MUI gaps", () => {
   });
 
   it("virtualizes desktop rows when enabled", () => {
-    vi.mocked(useChromeBodyData).mockReturnValue({
-      virtualization: {
-        enabled: true,
-        rows: [
-          {
-            row: { id: "b", name: "Bob" },
-            index: 1,
-            key: "b",
-          } satisfies VirtualTableRow<Row>,
-        ],
-        paddingTop: 40,
-        paddingBottom: 40,
-        measureElement: vi.fn(),
-      },
-      loadMoreRef: { current: null },
-      canLoadMore: true,
-      virtualScrollRef: () => undefined,
-    });
+    mockBodyData(
+      [{ row: { id: "b", name: "Bob" }, index: 1, key: "b" }],
+      40,
+      40
+    );
     mount({ virtualize: true, estimateRowSize: 40 }, "infinite");
     expect(screen.queryByText("Alice")).toBeNull();
     expect(screen.getByText("Bob")).toBeInTheDocument();
   });
 
   it("virtualizes mobile cards when enabled", () => {
-    vi.mocked(useChromeBodyData).mockReturnValue({
-      virtualization: {
-        enabled: true,
-        rows: [
-          {
-            row: { id: "b", name: "Bob" },
-            index: 1,
-            key: "b",
-          } satisfies VirtualTableRow<Row>,
-        ],
-        paddingTop: 132,
-        paddingBottom: 0,
-        measureElement: vi.fn(),
-      },
-      loadMoreRef: { current: null },
-      canLoadMore: false,
-      virtualScrollRef: () => undefined,
-    });
+    mockBodyData(
+      [{ row: { id: "b", name: "Bob" }, index: 1, key: "b" }],
+      132,
+      0
+    );
     mount({ forceMobile: true, virtualize: true, estimateCardSize: 132 });
     expect(screen.queryByText("Alice")).toBeNull();
     expect(screen.getByText("Bob")).toBeInTheDocument();

--- a/packages/adapter-mui/src/DataTable.tsx
+++ b/packages/adapter-mui/src/DataTable.tsx
@@ -137,7 +137,10 @@ function useChromeProps<TRow>(props: Readonly<DataTableProps<TRow>>) {
     defaults: props.defaults,
     paginationMode: props.paginationMode,
     urlAdapter,
-    urlSync: props.urlSync,
+    // No `urlSync` here on purpose: the decision is already baked into WHICH
+    // adapter was resolved above (memory when off, the real one when on), and
+    // the tier hooks would otherwise apply it a second time — routing the
+    // active tier to a private store that saved views cannot see.
     urlKey: props.urlKey,
   });
   let filtersNode: ReactNode;

--- a/packages/adapter-mui/src/DataTable.tsx
+++ b/packages/adapter-mui/src/DataTable.tsx
@@ -1,21 +1,5 @@
-import type {
-  GroupCollapseState,
-  GroupedFlatEntry,
-  RowAction,
-  UseColumnLayoutResult,
-} from "@adapttable/core";
-import {
-  ACTIONS_COLUMN_KEY,
-  isDeclarativeFilters,
-  makeExportCsvHandler,
-  resolveLabels,
-  useChromeBodyData,
-  useChromeScrollReset,
-  useFilterTriggerToggle,
-  useTableChrome,
-  useTableData,
-} from "@adapttable/core";
-import { useMountStagger, useResolvedAdapter } from "@adapttable/core/adapter";
+import { resolveLabels } from "@adapttable/core";
+import { useDataTableShell, useMountStagger } from "@adapttable/core/adapter";
 import {
   Box,
   Button,
@@ -24,8 +8,6 @@ import {
   Stack,
   Typography,
 } from "@mui/material";
-import type { ReactNode } from "react";
-import { useRef, useState } from "react";
 
 import { Chips } from "./components/ActiveFilterChips";
 import { AutoFilterForm } from "./components/AutoFilterForm";
@@ -41,26 +23,6 @@ import { LoadingState } from "./components/TableSkeleton";
 import { Toolbar } from "./components/Toolbar";
 import type { DataTableProps } from "./types";
 
-/** Chrome grouping bundle shape (matches SharedTableRenderProps.grouping). */
-interface GroupingBundle<TRow> {
-  groupBy: string;
-  collapsed: GroupCollapseState;
-  entries: readonly GroupedFlatEntry<TRow>[];
-  setGroupBy: (key: string | null) => void;
-}
-
-/**
- * Prefer the (possibly virtual-windowed) flat entries from chrome body data
- * when grouping is armed; otherwise leave the bundle untouched / dormant.
- */
-function withWindowedGroupingEntries<TRow>(
-  grouping: GroupingBundle<TRow> | undefined,
-  groupingEntries: readonly GroupedFlatEntry<TRow>[] | undefined
-): GroupingBundle<TRow> | undefined {
-  if (!(grouping && groupingEntries)) return grouping;
-  return { ...grouping, entries: groupingEntries };
-}
-
 /**
  * Map row density to MUI's table `size`, independent of column pinning. An
  * explicit `size` prop still wins for backward compatibility.
@@ -71,102 +33,6 @@ function tableSize(
 ): "small" | "medium" {
   if (size) return size;
   return density === "compact" ? "small" : "medium";
-}
-
-/** The width setter only when column resize is enabled (opt-in). */
-function resizeSetter(
-  enabled: boolean | undefined,
-  setWidth: (key: string, width: number) => void
-): ((key: string, width: number) => void) | undefined {
-  return enabled ? setWidth : undefined;
-}
-
-/**
- * The injected actions column is first-class in column management: the
- * layout state treats keys opaquely, so the reserved "actions" key hides and
- * end-pins like any data column. Hiding strips `rowActions` BEFORE the
- * renderers, so the column, its pin lead, and the colSpans all disappear
- * consistently (desktop and mobile alike). `actionsPinned` reports the
- * Columns-menu end pin — only meaningful while the column renders.
- */
-function resolveActionsColumn<TRow>(
-  declared: RowAction<TRow>[] | undefined,
-  layout: UseColumnLayoutResult<TRow>
-): {
-  hasRowActions: boolean;
-  rowActions: RowAction<TRow>[] | undefined;
-  actionsPinned: boolean;
-} {
-  const hasRowActions = (declared?.length ?? 0) > 0;
-  const rowActions =
-    hasRowActions && !layout.isHidden(ACTIONS_COLUMN_KEY)
-      ? declared
-      : undefined;
-  const actionsPinned =
-    rowActions !== undefined &&
-    layout.state.pinned[ACTIONS_COLUMN_KEY] === "end";
-  return { hasRowActions, rowActions, actionsPinned };
-}
-
-/**
- * Resolve the data tier (`source` > `data` + `onQueryChange` > `data`) and
- * the filter content, then overlay them on the caller's props: caller JSX
- * filters pass through; the declarative array becomes the auto-built
- * {@link AutoFilterForm} (or nothing, when no definitions resolved); the
- * runtime's chip-label resolvers merge under any caller overrides.
- */
-function useChromeProps<TRow>(props: Readonly<DataTableProps<TRow>>) {
-  // ONE resolved URL backend for the tier hooks AND the saved-views menu,
-  // so with `urlSync={false}` both share the same in-memory backend instead
-  // of the menu silently reading the real address bar.
-  const urlAdapter = useResolvedAdapter(
-    props.urlSync === false ? undefined : props.urlAdapter,
-    props.urlSync !== false
-  );
-  const { source, runtime } = useTableData<TRow>({
-    locale: props.locale,
-    source: props.source,
-    data: props.data,
-    total: props.total,
-    loading: props.loading,
-    error: props.error,
-    mode: props.mode,
-    onQueryChange: props.onQueryChange,
-    columns: props.columns,
-    filters: props.filters,
-    defaults: props.defaults,
-    paginationMode: props.paginationMode,
-    urlAdapter,
-    // No `urlSync` here on purpose: the decision is already baked into WHICH
-    // adapter was resolved above (memory when off, the real one when on), and
-    // the tier hooks would otherwise apply it a second time — routing the
-    // active tier to a private store that saved views cannot see.
-    urlKey: props.urlKey,
-  });
-  let filtersNode: ReactNode;
-  // Column-level `filter` shorthands alone must still render the auto form —
-  // only explicit JSX takes over the drawing.
-  if (isDeclarativeFilters(props.filters) || props.filters === undefined) {
-    filtersNode =
-      runtime.defs.length > 0 ? (
-        <AutoFilterForm
-          defs={runtime.defs}
-          source={source}
-          labels={resolveLabels(props.labels)}
-        />
-      ) : undefined;
-  } else {
-    filtersNode = props.filters;
-  }
-  // `urlAdapter` is the RESOLVED backend from here on — downstream chrome
-  // (the saved-views menu) must share the table's own instance.
-  return {
-    ...props,
-    urlAdapter,
-    source,
-    filters: filtersNode,
-    filterLabels: { ...runtime.filterLabels, ...props.filterLabels },
-  };
 }
 
 /**
@@ -183,33 +49,37 @@ export function DataTable<TRow>(props: Readonly<DataTableProps<TRow>>) {
   const { slots, className, classNames, animate = false } = props;
   const size = tableSize(props.size, props.density);
   const { filtersMode = "popover" } = props;
-  const chromeProps = useChromeProps(props);
-  const { filters: filtersNode } = chromeProps;
-  const c = useTableChrome<TRow>(chromeProps);
-  // Everything rendered below reads the chrome's VIEW facade — identical to
-  // `source` except under grouping, where it presents the full rendered set.
-  const viewSource = c.source;
-  const { table, confirm, getRowId } = c;
-  const { labels } = table;
-  const [filtersOpen, setFiltersOpen] = useState(false);
-  const filtersTrigger = useFilterTriggerToggle(filtersOpen, setFiltersOpen);
-  const rootRef = useRef<HTMLDivElement>(null);
-  useChromeScrollReset(rootRef, c, chromeProps);
+  // The whole shared orchestration lives in core's shell; MUI adds only its
+  // kit's row `size` over the returned bundles.
+  const shell = useDataTableShell<TRow>(props, (defs, source) => (
+    <AutoFilterForm
+      defs={defs}
+      source={source}
+      labels={resolveLabels(props.labels)}
+    />
+  ));
   const {
-    virtualization,
-    groupingEntries,
+    chrome: c,
+    table,
+    labels,
+    filtersNode,
+    filtersOpen,
+    setFiltersOpen,
+    filtersTrigger,
+    rootRef,
     loadMoreRef,
     canLoadMore,
-    virtualScrollRef,
-  } = useChromeBodyData(c, chromeProps);
-  const grouping = withWindowedGroupingEntries(c.grouping, groupingEntries);
+    hasRowActions,
+    toolbarProps,
+  } = shell;
+  // Everything rendered below reads the chrome's VIEW facade — identical to
+  // the raw source except under grouping, where it presents the full set.
+  const viewSource = shell.source;
+  const { confirm } = c;
+  const tableProps = { ...shell.tableProps, size };
   useMountStagger(rootRef, [viewSource.rows.length, c.isMobile], {
     enabled: animate,
   });
-  const { hasRowActions, rowActions, actionsPinned } = resolveActionsColumn(
-    props.rowActions,
-    c.columnLayout
-  );
   const columnMenu = props.enableColumnMenu && !c.isMobile && (
     <ColumnMenu
       allColumns={c.allColumns}
@@ -224,7 +94,7 @@ export function DataTable<TRow>(props: Readonly<DataTableProps<TRow>>) {
   const savedViewsMenu = props.savedViews && (
     <SavedViewsMenu
       options={{
-        urlAdapter: chromeProps.urlAdapter,
+        urlAdapter: shell.urlAdapter,
         urlKey: props.urlKey,
         ...props.savedViews,
       }}
@@ -255,65 +125,11 @@ export function DataTable<TRow>(props: Readonly<DataTableProps<TRow>>) {
       </Stack>
     );
   } else if (c.body === "mobile") {
-    body = (
-      <MobileCards
-        table={table}
-        cardClassName={classNames?.card}
-        rows={c.editingRows}
-        rowActions={rowActions}
-        confirm={confirm}
-        getRowId={getRowId}
-        size={size}
-        dir={props.dir}
-        onRowClick={props.onRowClick}
-        rowClassName={props.rowClassName}
-        renderRowDetail={props.renderRowDetail}
-        summaryRow={props.summaryRow}
-        expansion={c.detail?.expansion}
-        editing={c.editing}
-        grouping={grouping}
-        rowEntries={virtualization.enabled ? virtualization.rows : undefined}
-        paddingTop={virtualization.paddingTop}
-        paddingBottom={virtualization.paddingBottom}
-        measureElement={virtualization.measureElement}
-      />
-    );
+    body = <MobileCards {...tableProps} cardClassName={classNames?.card} />;
   } else {
     body = (
       <Box className={classNames?.table}>
-        <DesktopTable
-          table={table}
-          rows={c.editingRows}
-          rowActions={rowActions}
-          actionsPinned={actionsPinned}
-          confirm={confirm}
-          getRowId={getRowId}
-          size={size}
-          dir={props.dir}
-          prefetch={props.prefetch}
-          onRowClick={props.onRowClick}
-          rowClassName={props.rowClassName}
-          renderRowDetail={props.renderRowDetail}
-          summaryRow={props.summaryRow}
-          expansion={c.detail?.expansion}
-          editing={c.editing}
-          grouping={grouping}
-          rowEntries={virtualization.enabled ? virtualization.rows : undefined}
-          paddingTop={virtualization.paddingTop}
-          paddingBottom={virtualization.paddingBottom}
-          measureElement={virtualization.measureElement}
-          stickyHeader={props.stickyHeader}
-          stickyTop={props.stickyTop}
-          pinOffset={c.columnLayout.pinOffset}
-          maxHeight={props.maxHeight}
-          virtualScrollRef={virtualScrollRef}
-          setWidth={resizeSetter(
-            props.resizableColumns,
-            c.columnLayout.setWidth
-          )}
-          columnWidths={c.columnLayout.state.widths}
-          resizeLabel={labels.resizeColumn}
-        />
+        <DesktopTable {...tableProps} prefetch={props.prefetch} />
       </Box>
     );
   }
@@ -332,29 +148,14 @@ export function DataTable<TRow>(props: Readonly<DataTableProps<TRow>>) {
       <Stack spacing={1.5}>
         <Box className={classNames?.toolbar}>
           <Toolbar
-            table={table}
-            searchable={props.searchable !== false}
-            searchPlaceholder={props.searchPlaceholder}
-            sortByOptions={props.sortByOptions}
-            toolbar={props.toolbar}
+            {...toolbarProps}
             savedViewsMenu={savedViewsMenu}
-            hasFilters={Boolean(filtersNode)}
-            activeFilterCount={c.activeFilterCount}
-            showRowsPerPage={canLoadMore}
             filtersMode={filtersMode}
-            filters={filtersNode}
             filtersOpen={filtersOpen}
             onToggleFilters={filtersTrigger.onClick}
             onFiltersTriggerPointerDown={filtersTrigger.onPointerDown}
             onCloseFilters={() => setFiltersOpen(false)}
-            onClearFilters={c.clearFilters}
-            dir={props.dir}
             columnMenu={columnMenu}
-            onExportCsv={makeExportCsvHandler(
-              props.exportCsv,
-              viewSource,
-              c.columnLayout.visibleColumns
-            )}
           />
         </Box>
         {c.isRefreshing && <LinearProgress aria-label={labels.loading} />}

--- a/packages/adapter-unstyled/src/DataTable.coverage.test.tsx
+++ b/packages/adapter-unstyled/src/DataTable.coverage.test.tsx
@@ -7,12 +7,7 @@
  * sticky header inside a bounded scroll box, the fixed-width table min-width,
  * the right-pinned actions edge, and the clickable mobile card.
  */
-import {
-  createMemoryAdapter,
-  useChromeBodyData,
-  useFrontendData,
-} from "@adapttable/core";
-import { type VirtualTableRow } from "@adapttable/core/adapter";
+import { createMemoryAdapter, useFrontendData } from "@adapttable/core";
 import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -31,30 +26,55 @@ const columns: ColumnDef<Row>[] = [
   { key: "name", header: "Name", accessor: (r) => r.name },
 ];
 
-vi.mock("@adapttable/core", async (importOriginal) => {
-  const actual = await importOriginal();
-  return {
-    ...(actual as object),
-    useChromeBodyData: vi.fn(),
-  };
+import type * as AdapterModule from "@adapttable/core/adapter";
+import { useDataTableShell } from "@adapttable/core/adapter";
+
+vi.mock("@adapttable/core/adapter", async (importOriginal) => {
+  const actual = await importOriginal<typeof AdapterModule>();
+  return { ...actual, useDataTableShell: vi.fn(actual.useDataTableShell) };
 });
+
+const actualAdapter = await vi.importActual<typeof AdapterModule>(
+  "@adapttable/core/adapter"
+);
+
+/**
+ * Force a controlled virtual window by overriding the shell's `tableProps` —
+ * the renderers read `rowEntries` exactly as from a real virtualizer.
+ */
+function mockVirtualWindow(top: number, bottom: number, indices = [0, 1]) {
+  vi.mocked(useDataTableShell).mockImplementation((props, render) => {
+    const real = actualAdapter.useDataTableShell(props, render);
+    return {
+      ...real,
+      tableProps: {
+        ...real.tableProps,
+        rowEntries: indices
+          .filter((index) => index < real.tableProps.rows.length)
+          .map((index) => ({
+            row: real.tableProps.rows[index]!,
+            index,
+            key: String(real.tableProps.getRowId(real.tableProps.rows[index])),
+          })),
+        paddingTop: top,
+        paddingBottom: bottom,
+        measureElement: () => undefined,
+      },
+    };
+  });
+}
+
+function restoreRealShell() {
+  vi.mocked(useDataTableShell).mockImplementation(
+    actualAdapter.useDataTableShell
+  );
+}
 
 let adapter: ReturnType<typeof createMemoryAdapter>;
 
 beforeEach(() => {
-  // Mirror the real hook's disabled state so non-virtual tests render the
-  // full row set with a working load-more gate.
-  vi.mocked(useChromeBodyData).mockImplementation((chrome, props) => ({
-    virtualization: {
-      enabled: false,
-      rows: [],
-      paddingTop: 0,
-      paddingBottom: 0,
-    },
-    loadMoreRef: { current: null },
-    canLoadMore: !chrome.isPaged && !props.source.error,
-    virtualScrollRef: () => undefined,
-  }));
+  // Default: the real shell, so non-virtual tests run untouched.
+  restoreRealShell();
 });
 
 function Harness(props: {
@@ -306,20 +326,7 @@ describe("<DataTable> (unstyled) branch coverage", () => {
   // tables.tsx:400 — mobile `paddingBottom > 0`, truthy side: a virtualized
   // mobile list with a trailing spacer.
   it("renders a trailing virtual spacer in mobile cards", () => {
-    vi.mocked(useChromeBodyData).mockReturnValue({
-      virtualization: {
-        enabled: true,
-        rows: [
-          { row: ROWS[1]!, index: 1, key: "b" } satisfies VirtualTableRow<Row>,
-        ],
-        paddingTop: 0,
-        paddingBottom: 120,
-        measureElement: vi.fn(),
-      },
-      loadMoreRef: { current: null },
-      canLoadMore: true,
-      virtualScrollRef: () => undefined,
-    });
+    mockVirtualWindow(0, 120, [1]);
     const { container } = renderHarness({
       isMobile: true,
       mode: "infinite",

--- a/packages/adapter-unstyled/src/DataTable.gaps.test.tsx
+++ b/packages/adapter-unstyled/src/DataTable.gaps.test.tsx
@@ -1,14 +1,9 @@
 /**
  * Gap-fill: mobile selection + row actions, footer interactions, and the
  * bulk disabled-reason path. Virtual-window rendering is driven through a
- * mocked `useChromeBodyData` (the loader wiring itself lives in core).
+ * an overridden shell window (the loader wiring itself lives in core).
  */
-import {
-  createMemoryAdapter,
-  useChromeBodyData,
-  useFrontendData,
-} from "@adapttable/core";
-import { type VirtualTableRow } from "@adapttable/core/adapter";
+import { createMemoryAdapter, useFrontendData } from "@adapttable/core";
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -27,30 +22,55 @@ const columns: ColumnDef<Row>[] = [
   { key: "name", header: "Name", accessor: (r) => r.name },
 ];
 
-vi.mock("@adapttable/core", async (importOriginal) => {
-  const actual = await importOriginal();
-  return {
-    ...(actual as object),
-    useChromeBodyData: vi.fn(),
-  };
+import type * as AdapterModule from "@adapttable/core/adapter";
+import { useDataTableShell } from "@adapttable/core/adapter";
+
+vi.mock("@adapttable/core/adapter", async (importOriginal) => {
+  const actual = await importOriginal<typeof AdapterModule>();
+  return { ...actual, useDataTableShell: vi.fn(actual.useDataTableShell) };
 });
+
+const actualAdapter = await vi.importActual<typeof AdapterModule>(
+  "@adapttable/core/adapter"
+);
+
+/**
+ * Force a controlled virtual window by overriding the shell's `tableProps` —
+ * the renderers read `rowEntries` exactly as from a real virtualizer.
+ */
+function mockVirtualWindow(top: number, bottom: number, indices = [0, 1]) {
+  vi.mocked(useDataTableShell).mockImplementation((props, render) => {
+    const real = actualAdapter.useDataTableShell(props, render);
+    return {
+      ...real,
+      tableProps: {
+        ...real.tableProps,
+        rowEntries: indices
+          .filter((index) => index < real.tableProps.rows.length)
+          .map((index) => ({
+            row: real.tableProps.rows[index]!,
+            index,
+            key: String(real.tableProps.getRowId(real.tableProps.rows[index])),
+          })),
+        paddingTop: top,
+        paddingBottom: bottom,
+        measureElement: () => undefined,
+      },
+    };
+  });
+}
+
+function restoreRealShell() {
+  vi.mocked(useDataTableShell).mockImplementation(
+    actualAdapter.useDataTableShell
+  );
+}
 
 let adapter: ReturnType<typeof createMemoryAdapter>;
 
 beforeEach(() => {
-  // Mirror the real hook's disabled state so non-virtual tests render the
-  // full row set with a working load-more gate.
-  vi.mocked(useChromeBodyData).mockImplementation((chrome, props) => ({
-    virtualization: {
-      enabled: false,
-      rows: [],
-      paddingTop: 0,
-      paddingBottom: 0,
-    },
-    loadMoreRef: { current: null },
-    canLoadMore: !chrome.isPaged && !props.source.error,
-    virtualScrollRef: () => undefined,
-  }));
+  // Default: the real shell, so non-virtual tests run untouched.
+  restoreRealShell();
 });
 
 function Harness(props: {
@@ -242,24 +262,7 @@ describe("<DataTable> (unstyled) gaps", () => {
   });
 
   it("virtualizes desktop rows when enabled", () => {
-    vi.mocked(useChromeBodyData).mockReturnValue({
-      virtualization: {
-        enabled: true,
-        rows: [
-          {
-            row: { id: "b", name: "Bob" },
-            index: 1,
-            key: "b",
-          } satisfies VirtualTableRow<Row>,
-        ],
-        paddingTop: 40,
-        paddingBottom: 40,
-        measureElement: vi.fn(),
-      },
-      loadMoreRef: { current: null },
-      canLoadMore: true,
-      virtualScrollRef: () => undefined,
-    });
+    mockVirtualWindow(40, 40, [1]);
     renderHarness({
       mode: "infinite",
       override: { virtualize: true, estimateRowSize: 40 },
@@ -269,24 +272,7 @@ describe("<DataTable> (unstyled) gaps", () => {
   });
 
   it("virtualizes mobile cards when enabled", () => {
-    vi.mocked(useChromeBodyData).mockReturnValue({
-      virtualization: {
-        enabled: true,
-        rows: [
-          {
-            row: { id: "b", name: "Bob" },
-            index: 1,
-            key: "b",
-          } satisfies VirtualTableRow<Row>,
-        ],
-        paddingTop: 132,
-        paddingBottom: 0,
-        measureElement: vi.fn(),
-      },
-      loadMoreRef: { current: null },
-      canLoadMore: true,
-      virtualScrollRef: () => undefined,
-    });
+    mockVirtualWindow(132, 0, [1]);
     renderHarness({
       isMobile: true,
       mode: "infinite",

--- a/packages/adapter-unstyled/src/DataTable.tsx
+++ b/packages/adapter-unstyled/src/DataTable.tsx
@@ -1,18 +1,6 @@
-import {
-  ACTIONS_COLUMN_KEY,
-  isDeclarativeFilters,
-  makeExportCsvHandler,
-  type TableSource,
-  type TableVirtualization,
-  useChromeBodyData,
-  useChromeScrollReset,
-  useFilterTriggerToggle,
-  useTableChrome,
-  useTableData,
-} from "@adapttable/core";
-import { useMountStagger, useResolvedAdapter } from "@adapttable/core/adapter";
+import { makeExportCsvHandler, type TableSource } from "@adapttable/core";
+import { useDataTableShell, useMountStagger } from "@adapttable/core/adapter";
 import type { ReactElement, ReactNode, RefObject } from "react";
-import { useRef, useState } from "react";
 
 import { Chips } from "./components/ActiveFilterChips";
 import { AutoFilterForm } from "./components/AutoFilterForm";
@@ -47,38 +35,29 @@ type ResolvedDataTableProps<TRow> = Omit<
   filters?: ReactNode;
 };
 
+/** The shell's return shape, derived so no extra public type is needed. */
+type ShellResult<TRow> = ReturnType<typeof useDataTableShell<TRow>>;
+
 interface DataTableBodyProps<TRow> {
-  chrome: ReturnType<typeof useTableChrome<TRow>>;
+  chrome: ShellResult<TRow>["chrome"];
   props: Readonly<ResolvedDataTableProps<TRow>>;
   classNames: NonNullable<DataTableProps<TRow>["classNames"]>;
-  confirm: ReturnType<typeof useTableChrome<TRow>>["confirm"];
-  getRowId: ReturnType<typeof useTableChrome<TRow>>["getRowId"];
-  virtualization: TableVirtualization<TRow>;
-  virtualScrollRef: (node: HTMLElement | null) => void;
-  labels: ReturnType<typeof useTableChrome<TRow>>["table"]["labels"];
-  grouping: ReturnType<typeof useTableChrome<TRow>>["grouping"];
+  labels: ShellResult<TRow>["labels"];
+  /** The shell's kit-agnostic render bundle, spread straight onto the renderer. */
+  tableProps: ShellResult<TRow>["tableProps"];
 }
 
 function DataTableBody<TRow>({
   chrome,
   props,
   classNames,
-  confirm,
-  getRowId,
-  virtualization,
-  virtualScrollRef,
   labels,
-  grouping,
+  tableProps,
 }: Readonly<DataTableBodyProps<TRow>>): ReactElement {
-  // The injected actions column obeys the user column layout like any data
-  // column: hiding it strips `rowActions` before the renderers (desktop and
-  // cards alike), and an end-pin sticks it without needing a data pin.
-  const rowActions = chrome.columnLayout.isHidden(ACTIONS_COLUMN_KEY)
-    ? undefined
-    : props.rowActions;
-  const actionsPinned =
-    (rowActions?.length ?? 0) > 0 &&
-    chrome.columnLayout.state.pinned[ACTIONS_COLUMN_KEY] !== undefined;
+  // The shell already applied the column layout to the injected actions
+  // column: hidden strips `rowActions` before the renderers, an end pin sets
+  // `actionsPinned`.
+  const rowActions = tableProps.rowActions;
   if (chrome.body === "skeleton") {
     return (
       <>
@@ -120,39 +99,7 @@ function DataTableBody<TRow>({
     );
   }
   const Renderer = chrome.isMobile ? MobileCards : DesktopTable;
-  return (
-    <Renderer
-      table={chrome.table}
-      rows={chrome.editingRows}
-      rowActions={rowActions}
-      actionsPinned={actionsPinned}
-      confirm={confirm}
-      getRowId={getRowId}
-      classNames={classNames}
-      prefetch={props.prefetch}
-      onRowClick={props.onRowClick}
-      rowClassName={props.rowClassName}
-      renderRowDetail={props.renderRowDetail}
-      summaryRow={props.summaryRow}
-      expansion={chrome.detail?.expansion}
-      editing={chrome.editing}
-      grouping={grouping}
-      rowEntries={virtualization.enabled ? virtualization.rows : undefined}
-      paddingTop={virtualization.paddingTop}
-      paddingBottom={virtualization.paddingBottom}
-      measureElement={virtualization.measureElement}
-      stickyHeader={props.stickyHeader}
-      stickyTop={props.stickyTop}
-      pinOffset={chrome.columnLayout.pinOffset}
-      maxHeight={props.maxHeight}
-      virtualScrollRef={virtualScrollRef}
-      setWidth={
-        props.resizableColumns ? chrome.columnLayout.setWidth : undefined
-      }
-      columnWidths={chrome.columnLayout.state.widths}
-      resizeLabel={labels.resizeColumn}
-    />
-  );
+  return <Renderer {...tableProps} classNames={classNames} />;
 }
 
 /**
@@ -164,12 +111,6 @@ function DataTableBody<TRow>({
  */
 export function DataTable<TRow>(props: Readonly<DataTableProps<TRow>>) {
   const {
-    data,
-    total,
-    loading,
-    onQueryChange,
-    urlAdapter,
-    urlKey,
     searchPlaceholder,
     sortByOptions,
     dir,
@@ -182,85 +123,44 @@ export function DataTable<TRow>(props: Readonly<DataTableProps<TRow>>) {
 
   const density = props.density ?? "comfortable";
 
-  // ONE resolved URL backend for the tier hooks AND the saved-views menu,
-  // so with `urlSync={false}` both share the same in-memory backend instead
-  // of the menu silently reading the real address bar.
-  const resolvedUrlAdapter = useResolvedAdapter(
-    props.urlSync === false ? undefined : urlAdapter,
-    props.urlSync !== false
-  );
-  // Resolve the data tier (prebuilt source > server > frontend) and the
-  // declarative-filter runtime (URL keys, chip labels, predicate).
-  const { source, runtime } = useTableData<TRow>({
-    locale: props.locale,
-    source: props.source,
-    data,
-    total,
-    loading,
-    error: props.error,
-    mode: props.mode,
-    onQueryChange,
-    urlAdapter: resolvedUrlAdapter,
-    // No `urlSync` here on purpose: the decision is already baked into WHICH
-    // adapter was resolved above (memory when off, the real one when on), and
-    // the tier hooks would otherwise apply it a second time — routing the
-    // active tier to a private store that saved views cannot see.
-    urlKey,
-    columns: props.columns,
-    filters: props.filters,
-    defaults: props.defaults,
-    paginationMode: props.paginationMode,
-  });
-
-  // The declarative array becomes the auto-built form; JSX passes through.
-  const autoForm =
-    runtime.defs.length > 0 ? (
-      <AutoFilterForm
-        defs={runtime.defs}
-        source={source}
-        classNames={classNames}
-        labels={props.labels}
-      />
-    ) : undefined;
-  // Column-level `filter` shorthands alone must still render the auto form —
-  // only explicit JSX takes over the drawing.
-  const filters =
-    isDeclarativeFilters(props.filters) || props.filters === undefined
-      ? autoForm
-      : props.filters;
-
-  // Everything downstream sees the RESOLVED source and plain-JSX filters,
-  // with the runtime's chip labels under the caller's overrides.
+  // The whole shared orchestration — data tier, filter runtime, chrome,
+  // scroll reset, body windowing — lives in core's shell; this file renders
+  // only semantic markup with class hooks over it.
+  const shell = useDataTableShell<TRow>(props, (defs, source) => (
+    <AutoFilterForm
+      defs={defs}
+      source={source}
+      classNames={classNames}
+      labels={props.labels}
+    />
+  ));
+  const {
+    chrome,
+    table,
+    labels,
+    filtersNode: filters,
+    filtersOpen,
+    setFiltersOpen,
+    filtersTrigger,
+    rootRef,
+    canLoadMore,
+    tableProps,
+  } = shell;
+  // Everything rendered below reads the chrome's VIEW facade — identical to
+  // the raw source except under grouping, where it presents the full set.
+  const viewSource = shell.source;
   const chromeProps: ResolvedDataTableProps<TRow> = {
     ...props,
-    source,
+    source: viewSource,
     filters,
-    filterLabels: { ...runtime.filterLabels, ...props.filterLabels },
   };
-
-  const chrome = useTableChrome<TRow>(chromeProps);
-  const { table, confirm, getRowId } = chrome;
-  // Everything rendered below reads the chrome's VIEW facade — identical to
-  // `source` except under grouping, where it presents the full rendered set.
-  const viewSource = chrome.source;
-  const { labels } = table;
-  const [filtersOpen, setFiltersOpen] = useState(false);
-  const filtersTrigger = useFilterTriggerToggle(filtersOpen, setFiltersOpen);
-  const rootRef = useRef<HTMLDivElement>(null);
-  useChromeScrollReset(rootRef, chrome, chromeProps);
   useMountStagger(rootRef, [viewSource.rows.length, chrome.isMobile], {
     enabled: animate,
   });
-  const bodyData = useChromeBodyData(chrome, chromeProps);
-  const { virtualization, groupingEntries, canLoadMore } = bodyData;
-  const grouping =
-    chrome.grouping && groupingEntries
-      ? { ...chrome.grouping, entries: groupingEntries }
-      : chrome.grouping;
   // React 18's `ref` attribute rejects core's `RefObject<HTMLDivElement |
   // null>` through interface variance; the same object viewed through its
   // structural shape attaches fine.
-  const loadMoreRef: RefObject<HTMLDivElement | null> = bodyData.loadMoreRef;
+  const loadMoreRef: RefObject<HTMLDivElement | null> = shell.loadMoreRef;
   const searchProps = table.getSearchInputProps(
     searchPlaceholder ? { placeholder: searchPlaceholder } : undefined
   );
@@ -363,11 +263,11 @@ export function DataTable<TRow>(props: Readonly<DataTableProps<TRow>>) {
               aria-label={labels.sortBy}
               data-adapttable-part="sort-select"
               className={classNames.sortSelect}
-              value={source.sortBy ?? ""}
+              value={viewSource.sortBy ?? ""}
               onChange={(e) =>
-                source.setSort(
+                viewSource.setSort(
                   e.currentTarget.value || undefined,
-                  source.sortDir ?? "asc"
+                  viewSource.sortDir ?? "asc"
                 )
               }
             >
@@ -404,8 +304,8 @@ export function DataTable<TRow>(props: Readonly<DataTableProps<TRow>>) {
           // own props (explicit option values still win).
           <SavedViewsMenu
             options={{
-              urlAdapter: resolvedUrlAdapter,
-              urlKey,
+              urlAdapter: shell.urlAdapter,
+              urlKey: props.urlKey,
               ...props.savedViews,
             }}
             labels={labels}
@@ -466,7 +366,7 @@ export function DataTable<TRow>(props: Readonly<DataTableProps<TRow>>) {
           selection={table.selection}
           total={viewSource.total}
           bulkActions={bulkActions}
-          confirm={confirm}
+          confirm={chrome.confirm}
           labels={labels}
           classNames={classNames}
         />
@@ -496,12 +396,8 @@ export function DataTable<TRow>(props: Readonly<DataTableProps<TRow>>) {
           chrome={chrome}
           props={chromeProps}
           classNames={classNames}
-          confirm={confirm}
-          getRowId={getRowId}
-          virtualization={virtualization}
-          virtualScrollRef={bodyData.virtualScrollRef}
           labels={labels}
-          grouping={grouping}
+          tableProps={tableProps}
         />
       )}
 

--- a/packages/adapter-unstyled/src/DataTable.tsx
+++ b/packages/adapter-unstyled/src/DataTable.tsx
@@ -201,7 +201,10 @@ export function DataTable<TRow>(props: Readonly<DataTableProps<TRow>>) {
     mode: props.mode,
     onQueryChange,
     urlAdapter: resolvedUrlAdapter,
-    urlSync: props.urlSync,
+    // No `urlSync` here on purpose: the decision is already baked into WHICH
+    // adapter was resolved above (memory when off, the real one when on), and
+    // the tier hooks would otherwise apply it a second time — routing the
+    // active tier to a private store that saved views cannot see.
     urlKey,
     columns: props.columns,
     filters: props.filters,

--- a/packages/adapter-unstyled/src/classNamesParity.test.tsx
+++ b/packages/adapter-unstyled/src/classNamesParity.test.tsx
@@ -3,28 +3,62 @@
  * class of its camelCased key, and every key's class shows up in at least
  * one rendered state — the two surfaces can never drift apart again.
  */
-import type * as CoreModule from "@adapttable/core";
 import {
   createMemoryAdapter,
   type FilterDef,
-  useChromeBodyData,
   useFrontendData,
 } from "@adapttable/core";
+import type * as AdapterModule from "@adapttable/core/adapter";
+import { useDataTableShell } from "@adapttable/core/adapter";
 import { act, fireEvent, render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DataTable } from "./DataTable";
 import type { ColumnDef, DataTableClassNames } from "./index";
 
-vi.mock("@adapttable/core", async (importOriginal) => {
-  const actual = await importOriginal<typeof CoreModule>();
-  return { ...actual, useChromeBodyData: vi.fn(actual.useChromeBodyData) };
+vi.mock("@adapttable/core/adapter", async (importOriginal) => {
+  const actual = await importOriginal<typeof AdapterModule>();
+  return { ...actual, useDataTableShell: vi.fn(actual.useDataTableShell) };
 });
 
-const actualCore = await vi.importActual<typeof CoreModule>("@adapttable/core");
+const actualAdapter = await vi.importActual<typeof AdapterModule>(
+  "@adapttable/core/adapter"
+);
+
+/**
+ * Force a controlled virtual window by overriding the shell's `tableProps` —
+ * the renderers read `rowEntries` exactly as from a real virtualizer.
+ */
+function mockVirtualWindow(top: number, bottom: number, indices = [0, 1]) {
+  vi.mocked(useDataTableShell).mockImplementation((props, render) => {
+    const real = actualAdapter.useDataTableShell(props, render);
+    return {
+      ...real,
+      tableProps: {
+        ...real.tableProps,
+        rowEntries: indices
+          .filter((index) => index < real.tableProps.rows.length)
+          .map((index) => ({
+            row: real.tableProps.rows[index]!,
+            index,
+            key: String(real.tableProps.getRowId(real.tableProps.rows[index])),
+          })),
+        paddingTop: top,
+        paddingBottom: bottom,
+        measureElement: () => undefined,
+      },
+    };
+  });
+}
+
+function restoreRealShell() {
+  vi.mocked(useDataTableShell).mockImplementation(
+    actualAdapter.useDataTableShell
+  );
+}
 
 beforeEach(() => {
-  vi.mocked(useChromeBodyData).mockImplementation(actualCore.useChromeBodyData);
+  restoreRealShell();
 });
 
 interface Row {
@@ -263,27 +297,14 @@ async function renderAllStates(classNames?: DataTableClassNames) {
   mount({ data: [], url: "q=zzz" }).unmount();
 
   // Virtualized window → spacers (desktop rows and mobile cards).
-  vi.mocked(useChromeBodyData).mockImplementation((chrome) => ({
-    virtualization: {
-      enabled: true,
-      rows: chrome.editingRows
-        .slice(0, 2)
-        .map((row, index) => ({ row, index, key: String(index) })),
-      paddingTop: 40,
-      paddingBottom: 40,
-      measureElement: () => undefined,
-    },
-    loadMoreRef: { current: null },
-    canLoadMore: false,
-    virtualScrollRef: () => undefined,
-  }));
+  mockVirtualWindow(40, 40);
   mount({ mode: "infinite", override: { virtualize: true } }).unmount();
   mount({
     mode: "infinite",
     isMobile: true,
     override: { virtualize: true },
   }).unmount();
-  vi.mocked(useChromeBodyData).mockImplementation(actualCore.useChromeBodyData);
+  restoreRealShell();
 
   return seen;
 }

--- a/packages/core/src/url/adapter.test.ts
+++ b/packages/core/src/url/adapter.test.ts
@@ -1,3 +1,4 @@
+import { renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -5,6 +6,7 @@ import {
   createMemoryAdapter,
   getHistoryAdapter,
   resetHistoryAdapter,
+  useResolvedAdapter,
 } from "./adapter";
 
 afterEach(() => {
@@ -125,5 +127,35 @@ describe("getHistoryAdapter", () => {
     a.setSearch("x=1");
     expect(a.getSearch()).toBe("x=1");
     vi.unstubAllGlobals();
+  });
+});
+
+describe("useResolvedAdapter", () => {
+  // `enabled: false` means "this hook is not syncing", so writes must land in
+  // memory whoever supplied the adapter. Resolving the caller's adapter first
+  // let a disabled hook write straight to the real URL.
+  it("ignores an explicit adapter while disabled", () => {
+    const explicit = createMemoryAdapter("");
+    const { result } = renderHook(() => useResolvedAdapter(explicit, false));
+    expect(result.current).not.toBe(explicit);
+
+    result.current.setSearch("q=leaked");
+    expect(explicit.getSearch()).toBe("");
+  });
+
+  it("uses the explicit adapter while enabled", () => {
+    const explicit = createMemoryAdapter("");
+    const { result } = renderHook(() => useResolvedAdapter(explicit, true));
+    expect(result.current).toBe(explicit);
+  });
+
+  it("keeps one memory adapter across renders while disabled", () => {
+    const explicit = createMemoryAdapter("");
+    const { result, rerender } = renderHook(() =>
+      useResolvedAdapter(explicit, false)
+    );
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
   });
 });

--- a/packages/core/src/url/adapter.ts
+++ b/packages/core/src/url/adapter.ts
@@ -143,8 +143,13 @@ export function useResolvedAdapter(
   const memoryRef = useRef<UrlStateAdapter | null>(null);
   memoryRef.current ??= createMemoryAdapter();
 
-  if (adapter) return adapter;
+  // `enabled` is checked FIRST and beats an explicit adapter: "not syncing"
+  // has to mean writes land in memory, whoever supplied the adapter. With the
+  // checks the other way round a disabled hook kept writing to the caller's
+  // real adapter, and every disabled hook sharing one adapter also collided
+  // in the namespace registry — which made a single table warn about itself.
   if (!enabled) return memoryRef.current;
+  if (adapter) return adapter;
   if (!isBrowser()) return memoryRef.current;
   return getHistoryAdapter();
 }

--- a/packages/core/src/url/useTableUrlState.test.tsx
+++ b/packages/core/src/url/useTableUrlState.test.tsx
@@ -213,6 +213,39 @@ describe("useTableUrlState", () => {
       expect(warn).not.toHaveBeenCalled();
       vi.restoreAllMocks();
     });
+
+    // A table mounts both data tiers on one adapter and disables the inactive
+    // one. While `urlSync: false` was ignored for an explicit adapter, both
+    // tiers claimed the same namespace and every single table warned about
+    // itself — the warning could not be silenced by any prop.
+    it("stays silent when a disabled second hook shares the adapter", () => {
+      const warn = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+      const adapter = createMemoryAdapter("");
+      renderHook(() => {
+        useTableUrlState({ urlAdapter: adapter });
+        useTableUrlState({ urlAdapter: adapter, urlSync: false });
+      });
+      expect(warn).not.toHaveBeenCalled();
+      vi.restoreAllMocks();
+    });
+
+    it("still warns when both sharers are actually syncing", () => {
+      const warn = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined);
+      const adapter = createMemoryAdapter("");
+      renderHook(() => {
+        useTableUrlState({ urlAdapter: adapter, urlSync: true });
+        useTableUrlState({ urlAdapter: adapter, urlSync: true });
+      });
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("share the URL namespace")
+      );
+      resetDevWarnings();
+      vi.restoreAllMocks();
+    });
   });
 
   describe("urlKey namespacing", () => {

--- a/packages/core/src/useDataTableShell.tsx
+++ b/packages/core/src/useDataTableShell.tsx
@@ -93,7 +93,10 @@ export function useDataTableShell<TRow>(
     mode: props.mode,
     onQueryChange: props.onQueryChange,
     urlAdapter,
-    urlSync: props.urlSync,
+    // No `urlSync` here on purpose: the decision is already baked into WHICH
+    // adapter was resolved above (memory when off, the real one when on), and
+    // the tier hooks would otherwise apply it a second time — routing the
+    // active tier to a private store that saved views cannot see.
     urlKey: props.urlKey,
     columns: props.columns,
     filters: props.filters,


### PR DESCRIPTION
## The bug

A single `<DataTable>` logged `two tables share the URL namespace "(bare)"` about itself, and no prop could silence it — `urlKey` renamed both sides equally.

`useResolvedAdapter` resolved an explicitly passed adapter **before** it checked whether the hook was syncing, so `enabled: false` was ignored whenever a caller supplied one. Two consequences:

- **A hook told not to sync still wrote through the caller's adapter.** With a router adapter, `urlSync={false}` state landed in the real address bar.
- **A table mounts both data tiers on one adapter and disables the inactive one**, so both tiers claimed the same URL namespace and every table warned about itself. The warning that exists to report a real two-table collision could not be told apart from the false positive.

`enabled` is now checked first and beats an explicit adapter. The shells that pre-resolve a backend stop forwarding `urlSync` to the tier hooks in turn: the choice already lives in which adapter they resolved, and applying it twice routes the active tier to a private store the saved-views menu cannot read.

The genuine collision — two syncing tables sharing a namespace — still warns.

## The shell refactor

That fix belongs in one place, but four adapters carried their own copy of the orchestration, so it had to be written five times. `mantine`, `mui` and `unstyled` now call core's `useDataTableShell` for the data tier, URL backend, filter runtime, chrome, scroll reset and body windowing, keeping only what their kit needs — Mantine's measured sticky toolbar, per-body stagger refs and density; MUI's table size; unstyled's class presets and semantic markup. **459 lines of duplicated orchestration removed** (mui −199, mantine −156, unstyled −104).

One deliberate alignment: MUI's toolbar hides rows-per-page under grouping, matching every other adapter — page size has no effect on the grouped full set.

## Verification

- **551 adapter tests** green (mantine 187 · mui 157 · unstyled 207), plus core's suite
- Full `pnpm check` green — format, lint, types, coverage thresholds, build, publint, dist smoke
- Regression tests that fail without the fix: a lone table stays silent, a disabled hook never writes through an explicit adapter, and two syncing tables still warn
- Real browser across all three migrated kits: rows render, the filters overlay opens, URL state writes

## Release impact

`patch` for `@adapttable/core`, `mantine`, `mui`, `antd`, `unstyled`. chakra, radix and base-ui inherit through core; shadcn bumps as a dependent of unstyled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)