### PR TITLE
feat(sites): add Google Analytics to the docs and demo

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -55,6 +55,25 @@ export default defineConfig({
             "data-cf-beacon": '{"token": "dd71ff9f3b7b4064969d3f81e8c6ee9b"}',
           },
         },
+        // Google Analytics (GA4). Runs alongside the Cloudflare beacon: the
+        // beacon stays the cookieless baseline, GA4 adds funnel and event
+        // reporting.
+        {
+          tag: "script",
+          attrs: {
+            async: true,
+            src: "https://www.googletagmanager.com/gtag/js?id=G-FT8LY7Z15Y",
+          },
+        },
+        {
+          tag: "script",
+          content: [
+            "window.dataLayer = window.dataLayer || [];",
+            "function gtag(){dataLayer.push(arguments);}",
+            "gtag('js', new Date());",
+            "gtag('config', 'G-FT8LY7Z15Y');",
+          ].join("\n"),
+        },
       ],
       customCss: ["./src/styles/custom.css"],
       social: [

--- a/apps/docs/src/pages/index.astro
+++ b/apps/docs/src/pages/index.astro
@@ -154,6 +154,22 @@ const JSON_LD = JSON.stringify({
       src="https://static.cloudflareinsights.com/beacon.min.js"
       data-cf-beacon='{"token": "dd71ff9f3b7b4064969d3f81e8c6ee9b"}'
     ></script>
+    <!--
+      Google Analytics (GA4). This landing page is a standalone Astro page, so
+      Starlight's `head` config in astro.config.mjs does not reach it — the tag
+      is repeated here on purpose. Change the measurement ID in both places.
+    -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-FT8LY7Z15Y"></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+      gtag("config", "G-FT8LY7Z15Y");
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/apps/showcase/vite.config.ts
+++ b/apps/showcase/vite.config.ts
@@ -2,7 +2,41 @@ import { fileURLToPath } from "node:url";
 
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
+
+const GA_MEASUREMENT_ID = "G-FT8LY7Z15Y";
+
+/**
+ * Inject Google Analytics (GA4) into every HTML entry.
+ *
+ * The showcase is a multi-page app, so this lives here rather than being
+ * pasted into each `index.html` — one definition covers all seven pages and
+ * any page added later. The docs site injects the same tag through Starlight's
+ * `head` config.
+ */
+const googleAnalytics = (): Plugin => ({
+  name: "adapttable-google-analytics",
+  transformIndexHtml: () => [
+    {
+      tag: "script",
+      attrs: {
+        async: true,
+        src: `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`,
+      },
+      injectTo: "head",
+    },
+    {
+      tag: "script",
+      children: [
+        "window.dataLayer = window.dataLayer || [];",
+        "function gtag(){dataLayer.push(arguments);}",
+        "gtag('js', new Date());",
+        `gtag('config', '${GA_MEASUREMENT_ID}');`,
+      ].join("\n"),
+      injectTo: "head",
+    },
+  ],
+});
 
 // Resolve each @adapttable/* package to its TypeScript source so the showcase
 // always reflects the current library (and hot-reloads). The adapters are still
@@ -16,7 +50,7 @@ const page = (rel: string) => fileURLToPath(new URL(rel, import.meta.url));
 
 export default defineConfig({
   base: "./",
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), googleAnalytics()],
   // Multi-page app: each demo page is its own static HTML entry, linked
   // with plain anchors — no client router, no GitHub Pages 404 tricks.
   build: {


### PR DESCRIPTION
## What

Adds the GA4 tag (`G-FT8LY7Z15Y`) to every page of the docs site and the demo.
The Cloudflare beacon stays in place on both.

### Docs — two injection points, not one

`apps/docs/astro.config.mjs` adds the tag to Starlight's `head` array, which
covers the documentation pages.

The landing page is a standalone Astro page (`src/pages/index.astro`) that
Starlight's `head` config does not reach — a first build confirmed it as one of
two untagged pages. It carries the tag directly, with a comment noting the
measurement ID exists in both places.

### Demo — one plugin, seven entries

The showcase is a multi-page build. `apps/showcase/vite.config.ts` gains a
`transformIndexHtml` plugin so the tag is defined once and injected into all
seven HTML entries, and into any page added later, rather than being pasted
per file.

## Verification

Coverage counted in the built output:

| Site | HTML pages | Tagged |
| --- | --- | --- |
| `apps/docs/dist` | 32 | **31** |
| `apps/showcase/dist` | 7 | **7** |

The single untagged file is `google460b19df01c1ea76.html`, the Search Console
verification file, which stays bare.

`pnpm check` green — format, lint, lint:root, readmes, docsurface, typecheck,
test:coverage, build, publint, smoke:dist — and again via the pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)