### PR TITLE
chore(deps): patch the remaining brace-expansion advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,8 @@ overrides:
   sharp: ^0.35.0
   js-yaml@3: ^3.15.0
   js-yaml@4: ^4.3.0
+  brace-expansion@1: ^1.1.16
+  brace-expansion@5: ^5.0.7
 
 importers:
 
@@ -4935,12 +4937,12 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  brace-expansion@1.1.15:
-    resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -12579,12 +12581,12 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  brace-expansion@1.1.15:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -14617,15 +14619,15 @@ snapshots:
 
   minimatch@10.2.3:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.15
+      brace-expansion: 1.1.18
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,3 +34,7 @@ overrides:
   # merge-key chains force quadratic CPU; both majors are in the tree
   "js-yaml@3": "^3.15.0"
   "js-yaml@4": "^4.3.0"
+  # DoS via exponential-time expansion of consecutive non-expanding {} groups;
+  # both majors are in the tree (glob/minimatch transitives)
+  "brace-expansion@1": "^1.1.16"
+  "brace-expansion@5": "^5.0.7"


### PR DESCRIPTION
## What

Clears the last two open Dependabot advisories — both HIGH, both
`brace-expansion`: DoS via exponential-time expansion of consecutive
non-expanding `{}` groups.

| Major | Before | After | Required |
| --- | --- | --- | --- |
| 1.x | 1.1.15 | **1.1.18** | ≥ 1.1.16 |
| 5.x | 5.0.6 | **5.0.9** | ≥ 5.0.7 |

Both arrive as `glob` / `minimatch` transitives and are pinned by their
parents' ranges, so they need scoped overrides. The scope matters: a single
`"brace-expansion": "^5.0.7"` would force v1 consumers onto v5.

No published package depends on either — dev tooling only, so nothing under
`packages/` changed.

## Verification

`pnpm check` green — format, lint, lint:root, readmes, docsurface, typecheck,
test:coverage, build, publint, smoke:dist.

Resolved versions confirmed in the lockfile after install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)