### PR TITLE
chore(examples): add a Base UI example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,7 @@ complete, copy-pasteable React component — wrap it in your kit's provider
 | [chakra-selection.tsx](./chakra-selection.tsx)             | `@adapttable/chakra`   | Selection + bulk actions                       |
 | [antd-basic.tsx](./antd-basic.tsx)                         | `@adapttable/antd`     | AntD table, dark mode, row actions             |
 | [radix-basic.tsx](./radix-basic.tsx)                       | `@adapttable/radix`    | Radix Themes: theme-driven appearance          |
+| [base-ui-basic.tsx](./base-ui-basic.tsx)                   | `@adapttable/base-ui`  | Base UI primitives, self-injected styles       |
 | [shadcn-basic.tsx](./shadcn-basic.tsx)                     | `@adapttable/shadcn`   | shadcn/ui tokens, no provider                  |
 | [unstyled-tailwind.tsx](./unstyled-tailwind.tsx)           | `@adapttable/unstyled` | Tailwind classes + RTL/i18n                    |
 | [headless.tsx](./headless.tsx)                             | `@adapttable/core`     | Fully custom markup via prop-getters           |

--- a/examples/base-ui-basic.tsx
+++ b/examples/base-ui-basic.tsx
@@ -1,0 +1,56 @@
+import {
+  type ColumnDef,
+  DataTable,
+  useFrontendData,
+} from "@adapttable/base-ui";
+
+interface Person {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+}
+
+const PEOPLE: Person[] = [
+  { id: "1", name: "Ada Lovelace", email: "ada@example.com", role: "Engineer" },
+  { id: "2", name: "Alan Turing", email: "alan@example.com", role: "Founder" },
+  {
+    id: "3",
+    name: "Grace Hopper",
+    email: "grace@example.com",
+    role: "Admiral",
+  },
+];
+
+const columns: ColumnDef<Person>[] = [
+  { key: "name", header: "Name", accessor: (r) => r.name, sortable: true },
+  { key: "email", header: "Email", accessor: (r) => r.email },
+  { key: "role", header: "Role", accessor: (r) => r.role, sortable: true },
+];
+
+/**
+ * Base UI table: no provider and no stylesheet import — the adapter injects
+ * its own chrome CSS and renders Base UI's `Popover`, `Dialog`, `Select` and
+ * `Checkbox` for the overlays, so focus, portalling and z-index come from the
+ * kit. Search, sorting, pagination and URL-synced state come built in. Swap
+ * `useFrontendData` for `useQuerySource` to drive the same table from a
+ * server-paginated query.
+ */
+export function BaseUiBasicExample() {
+  const source = useFrontendData<Person>({ data: PEOPLE, columns });
+  return (
+    <DataTable
+      source={source}
+      columns={columns}
+      rowKey={(r) => r.id}
+      searchPlaceholder="Search people…"
+      rowActions={[
+        {
+          key: "edit",
+          label: "Edit",
+          onClick: (row) => alert(`Edit ${row.name}`),
+        },
+      ]}
+    />
+  );
+}

--- a/examples/package.json
+++ b/examples/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@adapttable/antd": "workspace:*",
+    "@adapttable/base-ui": "workspace:*",
     "@adapttable/chakra": "workspace:*",
     "@adapttable/core": "workspace:*",
     "@adapttable/i18n": "workspace:*",
@@ -20,6 +21,7 @@
     "@adapttable/unstyled": "workspace:*"
   },
   "devDependencies": {
+    "@base-ui/react": "^1.6.0",
     "@chakra-ui/react": "^3.36.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,9 @@ importers:
       '@adapttable/antd':
         specifier: workspace:*
         version: link:../packages/adapter-antd
+      '@adapttable/base-ui':
+        specifier: workspace:*
+        version: link:../packages/adapter-base-ui
       '@adapttable/chakra':
         specifier: workspace:*
         version: link:../packages/adapter-chakra
@@ -259,6 +262,9 @@ importers:
         specifier: workspace:*
         version: link:../packages/adapter-unstyled
     devDependencies:
+      '@base-ui/react':
+        specifier: ^1.6.0
+        version: 1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@chakra-ui/react':
         specifier: ^3.36.0
         version: 3.36.0(@emotion/react@11.14.0(@types/react@19.2.17)(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)


### PR DESCRIPTION
## What does this PR do?

Closes #111.

`@adapttable/base-ui` was the only adapter missing from `@adapttable/examples`, so it was the only one without a consumer-perspective compile check on every PR. This adds `examples/base-ui-basic.tsx`, wires the package into `examples/package.json`, and adds the row to the examples README table.

Two notes on the shape of it:

- The example needs no provider and no stylesheet import, since the adapter calls `ensureBaseUiStyles()` on import — so it ends up closer to `shadcn-basic.tsx` than to `radix-basic.tsx`, which it otherwise mirrors.
- `@base-ui/react` is in `devDependencies` because it's a peer of the adapter; without it the adapter's `.d.ts` doesn't resolve, even though the example never imports it directly.

No changeset — `@adapttable/examples` is private.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behaviour)
- [x] Docs / chore / refactor (no runtime behaviour change)

## Affected packages

No published package changes — the only source change is in the private `examples` workspace.

(The checklist above is missing `@adapttable/base-ui`, `@adapttable/radix` and `@adapttable/shadcn`. Happy to add them in a separate PR if useful.)

## Checklist

- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` all pass — ran `pnpm check` end to end, exit 0.
- [x] Added or updated tests for the change — the example *is* the check. `typecheck` depends on `^build`, so it compiles against the built `.d.ts` rather than source; I confirmed it has teeth by pointing a `rowActions` callback at a field that doesn't exist and watching `tsc` fail with `TS2339: Property 'nope' does not exist on type 'Person'`.
- [x] Behaviour is consistent across the affected adapters.
- [ ] Added a changeset — not applicable, the package is `private`.
- [x] Updated the docs / README if the public API or behaviour changed — added the examples README row.

---

Unrelated, but spotted while editing that table: the `mui-backend.tsx` row points at a file that no longer exists — it's `mui-query-source.tsx` now. Left it alone to keep this focused; happy to fix it here or in a separate PR, whichever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
