### PR TITLE
fix(ci): correct the docs-only filter in both directions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,16 @@ jobs:
             echo "full=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if printf '%s\n' "$diff_files" \
-            | grep -qvE '^(docs/|llms.*\.txt$|README\.md$|packages/[^/]+/README\.md$|\.github/|\.changeset/|ai_docs/)'; then
+          # The root README is a TEST INPUT: packages/cli/src/kits-docs.test.ts
+          # reads it and asserts every scaffoldable kit appears in the table.
+          # That guard lives in test:coverage, so a README-only diff must run
+          # the full gate — allowlisting it would skip the check that exists to
+          # catch exactly that drift.
+          if printf '%s\n' "$diff_files" | grep -qxE 'README\.md'; then
+            echo "Root README changed — it is a test input, running the full gate."
+            echo "full=true" >> "$GITHUB_OUTPUT"
+          elif printf '%s\n' "$diff_files" \
+            | grep -qvE '^(docs/|.*\.md$|llms.*\.txt$|.*/robots\.txt$|\.github/|\.changeset/|ai_docs/)'; then
             echo "full=true" >> "$GITHUB_OUTPUT"
           else
             echo "full=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Too strict — 40 files dragged the full gate

Every one of these fell outside the allowlist, so a markdown-only change ran
coverage, the three React versions, the packed-consumer harness and Playwright:

```
22 × CHANGELOG.md      (each package and starter)
12 × etc/*.api.md      (API reports)
     CONTRIBUTING.md · SECURITY.md · CODE_OF_CONDUCT.md
     examples/README.md · starters/README.md
 2 × robots.txt
```

PR #120 was a four-line markdown change and ran the whole matrix.

## Too loose — and this one is a correctness hole

The allowlist exempted the **root README**, which is a test input.
`packages/cli/src/kits-docs.test.ts` reads it and asserts every scaffoldable
kit appears in the table — and that test lives in `test:coverage`. So a
README-only change skipped the guard written to catch exactly that drift,
after Radix and shadcn once shipped as adapters while missing from the table.

`check:readmes` does not cover it: that script validates adapter READMEs
against the feature list, which is different ground.

## The fix

The root README now takes the full gate explicitly, with the reason in a
comment. Everything else that is markdown or a docs asset takes the light
path, where `format:check`, `check:readmes` and `check:docsurface` still run.

Verified against every tracked file:

| Input | Result |
| --- | --- |
| `examples/README.md`, `CONTRIBUTING.md`, `packages/*/CHANGELOG.md`, `etc/*.api.md`, `robots.txt` | light ✅ |
| **`README.md`** | **full — test input** ✅ |
| `packages/core/src/index.ts`, `vite.config.ts`, `pnpm-lock.yaml`, `package.json` | full ✅ |

## Verification

`pnpm check` green — format, lint, lint:root, readmes, docsurface, typecheck,
test:coverage, build, publint, smoke:dist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)