### PR TITLE
Give every showcase page a document heading and social metadata

### DIFF
--- a/apps/showcase/columns/index.html
+++ b/apps/showcase/columns/index.html
@@ -13,6 +13,21 @@
       href="https://orwa-mahmoud.github.io/adapttable/demo/columns/"
     />
     <meta name="robots" content="index, follow, max-image-preview:large" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="AdaptTable" />
+    <meta property="og:title" content="AdaptTable demo — column pin, resize, reorder" />
+    <meta property="og:description" content="AdaptTable column management demo — show/hide, drag-reorder, pin, and resize columns, then persist the layout to the URL." />
+    <meta property="og:url" content="https://orwa-mahmoud.github.io/adapttable/demo/columns/" />
+    <meta property="og:image" content="https://orwa-mahmoud.github.io/adapttable/og.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="AdaptTable demo — column pin, resize, reorder" />
+    <meta name="twitter:description" content="AdaptTable column management demo — show/hide, drag-reorder, pin, and resize columns, then persist the layout to the URL." />
+    <meta name="twitter:image" content="https://orwa-mahmoud.github.io/adapttable/og.png" />
+    <script type="application/ld+json">
+      {"@context":"https://schema.org","@type":"SoftwareApplication","name":"AdaptTable","description":"AdaptTable column management demo — show/hide, drag-reorder, pin, and resize columns, then persist the layout to the URL.","url":"https://orwa-mahmoud.github.io/adapttable/demo/columns/","applicationCategory":"DeveloperApplication","operatingSystem":"Any","license":"https://opensource.org/license/mit","programmingLanguage":"TypeScript","codeRepository":"https://github.com/orwa-mahmoud/adapttable","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}
+    </script>
     <!-- Cloudflare Web Analytics — cookieless, no consent banner needed. -->
     <script
       defer

--- a/apps/showcase/editing/index.html
+++ b/apps/showcase/editing/index.html
@@ -13,6 +13,21 @@
       href="https://orwa-mahmoud.github.io/adapttable/demo/editing/"
     />
     <meta name="robots" content="index, follow, max-image-preview:large" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="AdaptTable" />
+    <meta property="og:title" content="AdaptTable demo — inline cell editing" />
+    <meta property="og:description" content="AdaptTable inline cell editing demo — double-click any cell to edit it, with text, number and select editors and full keyboard commit." />
+    <meta property="og:url" content="https://orwa-mahmoud.github.io/adapttable/demo/editing/" />
+    <meta property="og:image" content="https://orwa-mahmoud.github.io/adapttable/og.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="AdaptTable demo — inline cell editing" />
+    <meta name="twitter:description" content="AdaptTable inline cell editing demo — double-click any cell to edit it, with text, number and select editors and full keyboard commit." />
+    <meta name="twitter:image" content="https://orwa-mahmoud.github.io/adapttable/og.png" />
+    <script type="application/ld+json">
+      {"@context":"https://schema.org","@type":"SoftwareApplication","name":"AdaptTable","description":"AdaptTable inline cell editing demo — double-click any cell to edit it, with text, number and select editors and full keyboard commit.","url":"https://orwa-mahmoud.github.io/adapttable/demo/editing/","applicationCategory":"DeveloperApplication","operatingSystem":"Any","license":"https://opensource.org/license/mit","programmingLanguage":"TypeScript","codeRepository":"https://github.com/orwa-mahmoud/adapttable","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}
+    </script>
     <!-- Cloudflare Web Analytics — cookieless, no consent banner needed. -->
     <script
       defer

--- a/apps/showcase/grouping/index.html
+++ b/apps/showcase/grouping/index.html
@@ -13,6 +13,21 @@
       href="https://orwa-mahmoud.github.io/adapttable/demo/grouping/"
     />
     <meta name="robots" content="index, follow, max-image-preview:large" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="AdaptTable" />
+    <meta property="og:title" content="AdaptTable demo — row grouping with subtotals" />
+    <meta property="og:description" content="AdaptTable row grouping demo — group rows by one column, collapse groups, and show per-group subtotals with inline cell editing." />
+    <meta property="og:url" content="https://orwa-mahmoud.github.io/adapttable/demo/grouping/" />
+    <meta property="og:image" content="https://orwa-mahmoud.github.io/adapttable/og.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="AdaptTable demo — row grouping with subtotals" />
+    <meta name="twitter:description" content="AdaptTable row grouping demo — group rows by one column, collapse groups, and show per-group subtotals with inline cell editing." />
+    <meta name="twitter:image" content="https://orwa-mahmoud.github.io/adapttable/og.png" />
+    <script type="application/ld+json">
+      {"@context":"https://schema.org","@type":"SoftwareApplication","name":"AdaptTable","description":"AdaptTable row grouping demo — group rows by one column, collapse groups, and show per-group subtotals with inline cell editing.","url":"https://orwa-mahmoud.github.io/adapttable/demo/grouping/","applicationCategory":"DeveloperApplication","operatingSystem":"Any","license":"https://opensource.org/license/mit","programmingLanguage":"TypeScript","codeRepository":"https://github.com/orwa-mahmoud/adapttable","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}
+    </script>
     <!-- Cloudflare Web Analytics — cookieless, no consent banner needed. -->
     <script
       defer

--- a/apps/showcase/mobile/index.html
+++ b/apps/showcase/mobile/index.html
@@ -13,6 +13,21 @@
       href="https://orwa-mahmoud.github.io/adapttable/demo/mobile/"
     />
     <meta name="robots" content="index, follow, max-image-preview:large" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="AdaptTable" />
+    <meta property="og:title" content="AdaptTable demo — automatic mobile cards" />
+    <meta property="og:description" content="The same React table becomes a card list on phones automatically — identical filters, selection and URL state, with infinite scroll." />
+    <meta property="og:url" content="https://orwa-mahmoud.github.io/adapttable/demo/mobile/" />
+    <meta property="og:image" content="https://orwa-mahmoud.github.io/adapttable/og.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="AdaptTable demo — automatic mobile cards" />
+    <meta name="twitter:description" content="The same React table becomes a card list on phones automatically — identical filters, selection and URL state, with infinite scroll." />
+    <meta name="twitter:image" content="https://orwa-mahmoud.github.io/adapttable/og.png" />
+    <script type="application/ld+json">
+      {"@context":"https://schema.org","@type":"SoftwareApplication","name":"AdaptTable","description":"The same React table becomes a card list on phones automatically — identical filters, selection and URL state, with infinite scroll.","url":"https://orwa-mahmoud.github.io/adapttable/demo/mobile/","applicationCategory":"DeveloperApplication","operatingSystem":"Any","license":"https://opensource.org/license/mit","programmingLanguage":"TypeScript","codeRepository":"https://github.com/orwa-mahmoud/adapttable","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}
+    </script>
     <!-- Cloudflare Web Analytics — cookieless, no consent banner needed. -->
     <script
       defer

--- a/apps/showcase/rtl/index.html
+++ b/apps/showcase/rtl/index.html
@@ -13,6 +13,21 @@
       href="https://orwa-mahmoud.github.io/adapttable/demo/rtl/"
     />
     <meta name="robots" content="index, follow, max-image-preview:large" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="AdaptTable" />
+    <meta property="og:title" content="AdaptTable demo — Arabic and right-to-left" />
+    <meta property="og:description" content="AdaptTable RTL demo — switch to Arabic and the whole table mirrors: toolbar, sort arrows, pinned columns, pagination. A genuinely flipped axis." />
+    <meta property="og:url" content="https://orwa-mahmoud.github.io/adapttable/demo/rtl/" />
+    <meta property="og:image" content="https://orwa-mahmoud.github.io/adapttable/og.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="AdaptTable demo — Arabic and right-to-left" />
+    <meta name="twitter:description" content="AdaptTable RTL demo — switch to Arabic and the whole table mirrors: toolbar, sort arrows, pinned columns, pagination. A genuinely flipped axis." />
+    <meta name="twitter:image" content="https://orwa-mahmoud.github.io/adapttable/og.png" />
+    <script type="application/ld+json">
+      {"@context":"https://schema.org","@type":"SoftwareApplication","name":"AdaptTable","description":"AdaptTable RTL demo — switch to Arabic and the whole table mirrors: toolbar, sort arrows, pinned columns, pagination. A genuinely flipped axis.","url":"https://orwa-mahmoud.github.io/adapttable/demo/rtl/","applicationCategory":"DeveloperApplication","operatingSystem":"Any","license":"https://opensource.org/license/mit","programmingLanguage":"TypeScript","codeRepository":"https://github.com/orwa-mahmoud/adapttable","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}
+    </script>
     <script
       defer
       src="https://static.cloudflareinsights.com/beacon.min.js"

--- a/apps/showcase/scale/index.html
+++ b/apps/showcase/scale/index.html
@@ -13,6 +13,21 @@
       href="https://orwa-mahmoud.github.io/adapttable/demo/scale/"
     />
     <meta name="robots" content="index, follow, max-image-preview:large" />
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="AdaptTable" />
+    <meta property="og:title" content="AdaptTable demo — 50,000 rows virtualized" />
+    <meta property="og:description" content="AdaptTable virtualization demo — scroll fifty thousand rows under a pinned sticky header with only a handful of DOM nodes." />
+    <meta property="og:url" content="https://orwa-mahmoud.github.io/adapttable/demo/scale/" />
+    <meta property="og:image" content="https://orwa-mahmoud.github.io/adapttable/og.png" />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="AdaptTable demo — 50,000 rows virtualized" />
+    <meta name="twitter:description" content="AdaptTable virtualization demo — scroll fifty thousand rows under a pinned sticky header with only a handful of DOM nodes." />
+    <meta name="twitter:image" content="https://orwa-mahmoud.github.io/adapttable/og.png" />
+    <script type="application/ld+json">
+      {"@context":"https://schema.org","@type":"SoftwareApplication","name":"AdaptTable","description":"AdaptTable virtualization demo — scroll fifty thousand rows under a pinned sticky header with only a handful of DOM nodes.","url":"https://orwa-mahmoud.github.io/adapttable/demo/scale/","applicationCategory":"DeveloperApplication","operatingSystem":"Any","license":"https://opensource.org/license/mit","programmingLanguage":"TypeScript","codeRepository":"https://github.com/orwa-mahmoud/adapttable","offers":{"@type":"Offer","price":"0","priceCurrency":"USD"}}
+    </script>
     <script
       defer
       src="https://static.cloudflareinsights.com/beacon.min.js"

--- a/apps/showcase/src/sections.tsx
+++ b/apps/showcase/src/sections.tsx
@@ -242,14 +242,21 @@ export function TrialCta() {
 }
 
 /** One small title + one helper line — the active nav tab already says
- * which page this is, so no kicker. */
+ * which page this is, so no kicker.
+ *
+ * The heading is an `h1`: every showcase page renders exactly one of these
+ * and it is that page's title, so it is the document heading. Screen readers
+ * and crawlers both read a page with no `h1` as having no subject — Bing
+ * reports "H1 tag missing" for a client-rendered page whose markup carries
+ * one only before React mounts. `sec__title` still carries the styling, so
+ * this changes semantics and nothing visual. */
 export function SectionHead({
   title,
   children,
 }: Readonly<{ title: string; children?: ReactNode }>) {
   return (
     <div className="sec__head">
-      <h2 className="sec__title">{title}</h2>
+      <h1 className="sec__title">{title}</h1>
       {children ? <p className="sec__lead">{children}</p> : null}
     </div>
   );


### PR DESCRIPTION
## What changed

The showcase is client-rendered, so its pages carried a heading only until React mounted. Once mounted the document had **no `h1` at all** — a screen reader reached the table with nothing naming the page, and Bing reported "H1 tag missing" on pages whose served markup does contain one.

- Each showcase page renders exactly one `SectionHead` and it is that page's title, so that heading is now the document heading (`h2` → `h1`).
- The six demo subpages gained the OpenGraph, Twitter and JSON-LD blocks the root demo page already had.

## Evidence

Rendered in a browser, post-mount:

| Page | h1 | computed style | JSON-LD | og:title |
| --- | --- | --- | --- | --- |
| `/demo/` | 1 | 22px / 700 / margin 0 | ✅ | ✅ |
| `/demo/scale/` | 1 | 22px / 700 / margin 0 | ✅ | ✅ |
| `/demo/rtl/` | 1 | 22px / 700 / margin 0 | ✅ | ✅ |
| `/demo/columns/` | 1 | 22px / 700 / margin 0 | ✅ | ✅ |

**No visual change.** `sec__title` sets `font-size`, `font-weight`, `margin` and `line-height` explicitly, so none of the browser defaults that differ between `h1` and `h2` apply. Computed style is identical before and after, and screenshots match.

`pnpm check` green.