### PR TITLE
Give each release job only the access it uses

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,9 @@ on:
 
 concurrency: release-${{ github.ref }}
 
-permissions:
-  contents: write
-  pull-requests: write
-  id-token: write
+# Nothing at this level: a token declared here reaches every job, including
+# ones that only read. Each job below asks for what it needs.
+permissions: {}
 
 jobs:
   # Skip cleanly until an NPM_TOKEN secret is configured, so pushes don't fail
@@ -19,6 +18,9 @@ jobs:
   # Secrets → Actions → NPM_TOKEN) and this activates automatically.
   guard:
     runs-on: ubuntu-latest
+    # Reads one secret's presence and writes a boolean to an output. It needs
+    # no access to the repository at all.
+    permissions: {}
     outputs:
       enabled: ${{ steps.check.outputs.enabled }}
     steps:
@@ -30,6 +32,12 @@ jobs:
     if: ${{ needs.guard.outputs.enabled == 'true' }}
     name: Version or Publish
     runs-on: ubuntu-latest
+    # contents: tag and commit the version bump · pull-requests: open the
+    # "Version Packages" PR · id-token: npm provenance on publish.
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
       TURBO_TEAM: ${{ secrets.TURBO_TEAM }}


### PR DESCRIPTION
## What changed

The release workflow declared its write permissions at the top level, so every job in it received them. The `guard` job reports whether an npm token exists and writes one boolean to an output — it was handed the ability to commit, open pull requests and mint an OIDC token to do it.

Permissions now sit on the job that uses them, each with the reason it exists.

```
top-level   {}                                    (was: contents + pull-requests + id-token)
  guard     {}                                    reads one secret's presence, writes a boolean
  release   contents · pull-requests · id-token   version tag · release PR · npm provenance
```

An empty top-level block means a job added later starts with no access and has to ask, rather than silently inheriting.

## Evidence

Triggers and all 5 release steps unchanged. `pnpm check` green.