### PR TITLE
Open the release PR with a repository-scoped token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,11 @@ jobs:
     if: ${{ needs.guard.outputs.enabled == 'true' }}
     name: Version or Publish
     runs-on: ubuntu-latest
-    # contents: tag and commit the version bump · pull-requests: open the
-    # "Version Packages" PR · id-token: npm provenance on publish.
+    # contents: tag and commit the version bump · id-token: npm provenance on
+    # publish. The "Version Packages" PR is opened with RELEASE_TOKEN, so the
+    # workflow token needs no pull-requests access.
     permissions:
       contents: write
-      pull-requests: write
       id-token: write
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -70,7 +70,12 @@ jobs:
           publish: pnpm release:gated
           version: pnpm version-packages
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # A fine-grained PAT scoped to this repository alone, with Contents
+          # and Pull requests write and nothing else. Repository settings deny
+          # the workflow token the ability to create pull requests, so this is
+          # the identity that opens the "Version Packages" PR — and because it
+          # is a real account, that PR runs the required checks.
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           # The version-bump commit must not run the husky gate on this


### PR DESCRIPTION
`changesets/action` authenticates with `RELEASE_TOKEN` — a fine-grained token
scoped to this repository alone, with Contents and Pull requests write and
nothing else. The "Version Packages" PR is opened by an account rather than by
the workflow token, so the required checks run on it.

The `release` job's workflow token now carries only what it still uses:
`contents: write` to check out and push the version branch, and `id-token:
write` for npm provenance. `pull-requests: write` is gone.

`pnpm check` green — format, lint, lint:root, check:readmes, check:docsurface,
typecheck, test:coverage, build, publint, smoke:dist.
