### PR TITLE
Point idea questions at Discussions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,8 +69,11 @@ A few things that trip people up the first time:
   [Changesets](#changesets) below — if you are unsure, add one; a `patch` is
   always a safe default.
 
-Small, focused PRs get reviewed fastest. If you are unsure whether an idea
-fits before you build it, open an issue first and ask.
+Small, focused PRs get reviewed fastest. If you are unsure whether an idea fits
+before you build it, ask in
+[Discussions](https://github.com/orwa-mahmoud/adapttable/discussions) — that is
+where questions and ideas belong. Issues are for bug reports and concrete
+feature proposals, each with its own template.
 
 ## Ground rules
 


### PR DESCRIPTION
The issue templates cover bug reports and concrete feature proposals, and the
template chooser already routes questions to Discussions. CONTRIBUTING said to
open an issue to ask whether an idea fits, which pointed the other way; it now
matches the templates.

`pnpm check` green — format, lint, doc guards, typecheck, coverage, build,
publint, dist smoke.
