### PR TITLE
Fix Feature Lab drawer behavior

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,24 +11,36 @@ look. Switching the kit in the live demo must change how the whole table
 looks, including the Filters popover and drawer: an MUI table filters with
 MUI controls, a Mantine table with Mantine controls.
 
-Unify the **model**, never the **pixels**:
+Unify the **model**, never the **pixels**. The standing pattern is
+**Chrome + slots**:
 
-- Do not add user-facing form controls to core — no inputs, selects,
-  checkboxes, buttons the end user clicks. Invisible chrome (live regions,
-  announcers, layout structure) is fine.
-- Feature parity means every kit has the feature **with its own components**,
-  the way `AutoFilterForm` works — one shared model in core, one thin input
-  layer per adapter. A shared look is not parity.
+- Core ships `*Chrome` components that own structure only — layout, the
+  recursion over groups, keyboard wiring, localized labels, and the
+  `data-adapttable-part` names — plus the headless hooks and state machines
+  behind them.
+- Every visible control (input, select, checkbox, button — anything the end
+  user clicks) is a **required slot** the adapter fills with its own kit's
+  component. Slots have no native fallback in core: a kit cannot silently
+  render raw HTML. `adapter-unstyled` supplies native controls because
+  native IS its kit; shadcn/tailwind build on unstyled.
+- Do not add user-facing controls to core, and do not give a slot a default
+  implementation. Invisible chrome (live regions, announcers, layout
+  structure) is fine in core.
+- Feature parity means every kit has the feature **with its own components**.
+  A shared look is not parity — copying one adapter's raw-HTML control into
+  another adapter is the same defect as drawing it in core.
 - If a kit's overlay or portal misbehaves inside the filter popover, fix it
   in that adapter (`disablePortal`, `getPopupContainer`, or that kit's native
-  select) — never by drawing the form in core.
-- Any native-HTML widget still exported from core is a leftover being moved
-  into the adapters, not a pattern to extend. New filter UI goes through
-  adapter components.
+  select) — never by weakening the slot contract.
+- `data-adapttable-part` names and placement are part of the public contract:
+  the same part lands on the same element in every adapter, and documented
+  `classNames` keys are honored by every adapter that renders the part.
 
 ## Product decisions — settled, do not reopen
 
-- Core is headless; adapters own appearance (above).
+- Core is headless; adapters own appearance. Chrome + slots (above) is the
+  settled widget architecture — do not reopen core-drawn controls or per-kit
+  copies of the layout.
 - Junior-friendly, senior-targeted: easy defaults for everyone, full control
   for experts — never trade one for the other.
 - One word per concept: `server` is the remote-tier word, `useQuerySource`

--- a/apps/showcase/src/AllOptionsDemo.tsx
+++ b/apps/showcase/src/AllOptionsDemo.tsx
@@ -1,4 +1,7 @@
-import { startTransition, Suspense, useEffect, useRef, useState } from "react";
+import { getLabels } from "@adapttable/i18n";
+import { FilterDrawer } from "@adapttable/mantine";
+import { MantineProvider } from "@mantine/core";
+import { startTransition, Suspense, useState } from "react";
 
 import { cssVars } from "./cssVars";
 import type { Locale } from "./data";
@@ -25,6 +28,14 @@ type OnOff = "on" | "off";
 type Structure = "flat" | "grouped" | "tree" | "nested";
 type EditingMode = "off" | "cell" | "row" | "batch";
 type Recipe = "baseline" | "filters" | "structure" | "editing" | "rows";
+
+const FEATURE_LAB_DRAWER_LABELS = {
+  ...getLabels("en"),
+  filters: "Configure Feature Lab",
+  clearAll: "Reset",
+  filtersDone: "Done",
+  cancel: "Close options",
+};
 
 const RECIPES: readonly {
   key: Recipe;
@@ -109,14 +120,6 @@ export function AllOptionsDemo({ dark }: Readonly<{ dark: boolean }>) {
   const [cellSpan, setCellSpan] = useState<OnOff>("off");
   const [extraRows, setExtraRows] = useState<OnOff>("off");
   const [rowStyle, setRowStyle] = useState<OnOff>("off");
-  const controlsRef = useRef<HTMLDialogElement>(null);
-
-  useEffect(() => {
-    const dialog = controlsRef.current;
-    if (!dialog) return;
-    if (controlsOpen && !dialog.open) dialog.showModal();
-    if (!controlsOpen && dialog.open) dialog.close();
-  }, [controlsOpen]);
 
   const token =
     ADAPTER_TOKENS.find((candidate) => candidate.key === adapter) ??
@@ -209,6 +212,11 @@ export function AllOptionsDemo({ dark }: Readonly<{ dark: boolean }>) {
     });
   };
 
+  const resetOptions = () => {
+    applyRecipe("baseline");
+    setLocale("en");
+  };
+
   const changeMode = (next: DataMode) => {
     startTransition(() => {
       setRecipe(null);
@@ -259,8 +267,8 @@ export function AllOptionsDemo({ dark }: Readonly<{ dark: boolean }>) {
 
       <div className="lab-toolbar">
         <div>
-          <strong>Full-width preview</strong>
-          <span>Options open over the canvas, never beside the table.</span>
+          <strong>Table options</strong>
+          <span>Configure data, filters, structure, editing, and rows.</span>
         </div>
         <button
           type="button"
@@ -274,188 +282,185 @@ export function AllOptionsDemo({ dark }: Readonly<{ dark: boolean }>) {
       </div>
 
       <div className="lab-layout">
-        <dialog
-          ref={controlsRef}
-          className="lab-drawer"
-          aria-labelledby="lab-drawer-title"
-          onCancel={() => setControlsOpen(false)}
-          onClose={() => setControlsOpen(false)}
-        >
-          <div className="lab-drawer__head">
-            <div>
-              <strong id="lab-drawer-title">Configure Feature Lab</strong>
-              <span>Only compatible combinations can be enabled.</span>
-            </div>
-            <button
-              type="button"
-              className="lab-drawer__close"
-              aria-label="Close options"
-              onClick={() => setControlsOpen(false)}
-            >
-              Close
-            </button>
-          </div>
-          <aside className="opt-board" aria-label="Feature Lab controls">
-            <ControlPanel title="Data and chrome">
-              <Control label="Data">
-                <Segmented
-                  label="data source"
-                  value={mode}
-                  onChange={changeMode}
-                  options={[
-                    { value: "frontend", label: "Frontend" },
-                    { value: "backend", label: "Backend" },
-                  ]}
-                />
-              </Control>
-              <Control label="Locale">
-                <Segmented
-                  label="locale"
-                  value={locale}
-                  onChange={(next) => customize(setLocale, next)}
-                  options={[
-                    { value: "en", label: "EN" },
-                    { value: "ar", label: "العربية" },
-                  ]}
-                />
-              </Control>
-              <Control label="Filter UI">
-                <Segmented
-                  label="filters container"
-                  value={filtersUi}
-                  onChange={(next) => customize(setFiltersUi, next)}
-                  options={[
-                    { value: "popover", label: "Popover" },
-                    { value: "drawer", label: "Drawer" },
-                    { value: "header", label: "Header" },
-                  ]}
-                />
-              </Control>
-              <Control label="Density">
-                <Segmented
-                  label="density"
-                  value={density}
-                  onChange={(next) => customize(setDensity, next)}
-                  options={[
-                    { value: "comfortable", label: "Comfortable" },
-                    { value: "compact", label: "Compact" },
-                  ]}
-                />
-              </Control>
-              <Toggle
-                label="Motion"
-                value={motion}
-                onChange={(next) => customize(setMotion, next)}
-              />
-            </ControlPanel>
+        <MantineProvider forceColorScheme={dark ? "dark" : "light"}>
+          <FilterDrawer
+            opened={controlsOpen}
+            onClose={() => setControlsOpen(false)}
+            filters={
+              <>
+                <p className="lab-options-drawer__intro">
+                  Only compatible combinations can be enabled.
+                </p>
+                <aside
+                  className="opt-board lab-options-drawer__controls"
+                  aria-label="Feature Lab controls"
+                >
+                  <ControlPanel title="Data and chrome">
+                    <Control label="Data">
+                      <Segmented
+                        label="data source"
+                        value={mode}
+                        onChange={changeMode}
+                        options={[
+                          { value: "frontend", label: "Frontend" },
+                          { value: "backend", label: "Backend" },
+                        ]}
+                      />
+                    </Control>
+                    <Control label="Locale">
+                      <Segmented
+                        label="locale"
+                        value={locale}
+                        onChange={(next) => customize(setLocale, next)}
+                        options={[
+                          { value: "en", label: "EN" },
+                          { value: "ar", label: "العربية" },
+                        ]}
+                      />
+                    </Control>
+                    <Control label="Filter UI">
+                      <Segmented
+                        label="filters container"
+                        value={filtersUi}
+                        onChange={(next) => customize(setFiltersUi, next)}
+                        options={[
+                          { value: "popover", label: "Popover" },
+                          { value: "drawer", label: "Drawer" },
+                          { value: "header", label: "Header" },
+                        ]}
+                      />
+                    </Control>
+                    <Control label="Density">
+                      <Segmented
+                        label="density"
+                        value={density}
+                        onChange={(next) => customize(setDensity, next)}
+                        options={[
+                          { value: "comfortable", label: "Comfortable" },
+                          { value: "compact", label: "Compact" },
+                        ]}
+                      />
+                    </Control>
+                    <Toggle
+                      label="Motion"
+                      value={motion}
+                      onChange={(next) => customize(setMotion, next)}
+                    />
+                  </ControlPanel>
 
-            <ControlPanel title="Structure">
-              <Control label="Row structure">
-                <Segmented
-                  label="row structure"
-                  value={structure}
-                  onChange={changeStructure}
-                  options={[
-                    { value: "flat", label: "Flat" },
-                    {
-                      value: "grouped",
-                      label: "Grouped",
-                      disabled: Boolean(clientOnlyReason),
-                      title: clientOnlyReason,
-                    },
-                    {
-                      value: "tree",
-                      label: "Tree",
-                      disabled: Boolean(clientOnlyReason),
-                      title: clientOnlyReason,
-                    },
-                    {
-                      value: "nested",
-                      label: "Detail",
-                      disabled: Boolean(clientOnlyReason),
-                      title: clientOnlyReason,
-                    },
-                  ]}
-                />
-              </Control>
-              <Toggle
-                label="Column groups"
-                value={columnGroups}
-                onChange={(next) => customize(setColumnGroups, next)}
-              />
-            </ControlPanel>
+                  <ControlPanel title="Structure">
+                    <Control label="Row structure">
+                      <Segmented
+                        label="row structure"
+                        value={structure}
+                        onChange={changeStructure}
+                        options={[
+                          { value: "flat", label: "Flat" },
+                          {
+                            value: "grouped",
+                            label: "Grouped",
+                            disabled: Boolean(clientOnlyReason),
+                            title: clientOnlyReason,
+                          },
+                          {
+                            value: "tree",
+                            label: "Tree",
+                            disabled: Boolean(clientOnlyReason),
+                            title: clientOnlyReason,
+                          },
+                          {
+                            value: "nested",
+                            label: "Detail",
+                            disabled: Boolean(clientOnlyReason),
+                            title: clientOnlyReason,
+                          },
+                        ]}
+                      />
+                    </Control>
+                    <Toggle
+                      label="Column groups"
+                      value={columnGroups}
+                      onChange={(next) => customize(setColumnGroups, next)}
+                    />
+                  </ControlPanel>
 
-            <ControlPanel title="Editing">
-              <Control label="Editing mode">
-                <Segmented
-                  label="editing mode"
-                  value={editingMode}
-                  onChange={(next) => customize(setEditingMode, next)}
-                  options={[
-                    { value: "off", label: "Off" },
-                    {
-                      value: "cell",
-                      label: "Cell",
-                      disabled: Boolean(clientOnlyReason),
-                      title: clientOnlyReason,
-                    },
-                    {
-                      value: "row",
-                      label: "Row",
-                      disabled: Boolean(clientOnlyReason),
-                      title: clientOnlyReason,
-                    },
-                    {
-                      value: "batch",
-                      label: "Batch",
-                      disabled: Boolean(clientOnlyReason),
-                      title: clientOnlyReason,
-                    },
-                  ]}
-                />
-              </Control>
-            </ControlPanel>
+                  <ControlPanel title="Editing">
+                    <Control label="Editing mode">
+                      <Segmented
+                        label="editing mode"
+                        value={editingMode}
+                        onChange={(next) => customize(setEditingMode, next)}
+                        options={[
+                          { value: "off", label: "Off" },
+                          {
+                            value: "cell",
+                            label: "Cell",
+                            disabled: Boolean(clientOnlyReason),
+                            title: clientOnlyReason,
+                          },
+                          {
+                            value: "row",
+                            label: "Row",
+                            disabled: Boolean(clientOnlyReason),
+                            title: clientOnlyReason,
+                          },
+                          {
+                            value: "batch",
+                            label: "Batch",
+                            disabled: Boolean(clientOnlyReason),
+                            title: clientOnlyReason,
+                          },
+                        ]}
+                      />
+                    </Control>
+                  </ControlPanel>
 
-            <ControlPanel title="Rows">
-              <Toggle
-                label="Add / delete"
-                value={rowMutations}
-                disabledOn={clientOnlyReason}
-                onChange={(next) => customize(setRowMutations, next)}
-              />
-              <Toggle
-                label="Reorder"
-                value={rowReorder}
-                disabledOn={reorderReason}
-                onChange={(next) => customize(setRowReorder, next)}
-              />
-              <Toggle
-                label="Pin rows"
-                value={rowPinning}
-                disabledOn={pinReason}
-                onChange={(next) => customize(setRowPinning, next)}
-              />
-              <Toggle
-                label="Span cells"
-                value={cellSpan}
-                disabledOn={clientOnlyReason}
-                onChange={(next) => customize(setCellSpan, next)}
-              />
-              <Toggle
-                label="Extra rows"
-                value={extraRows}
-                disabledOn={clientOnlyReason}
-                onChange={(next) => customize(setExtraRows, next)}
-              />
-              <Toggle
-                label="Row style"
-                value={rowStyle}
-                disabledOn={clientOnlyReason}
-                onChange={(next) => customize(setRowStyle, next)}
-              />
-            </ControlPanel>
-          </aside>
-        </dialog>
+                  <ControlPanel title="Rows">
+                    <Toggle
+                      label="Add / delete"
+                      value={rowMutations}
+                      disabledOn={clientOnlyReason}
+                      onChange={(next) => customize(setRowMutations, next)}
+                    />
+                    <Toggle
+                      label="Reorder"
+                      value={rowReorder}
+                      disabledOn={reorderReason}
+                      onChange={(next) => customize(setRowReorder, next)}
+                    />
+                    <Toggle
+                      label="Pin rows"
+                      value={rowPinning}
+                      disabledOn={pinReason}
+                      onChange={(next) => customize(setRowPinning, next)}
+                    />
+                    <Toggle
+                      label="Span cells"
+                      value={cellSpan}
+                      disabledOn={clientOnlyReason}
+                      onChange={(next) => customize(setCellSpan, next)}
+                    />
+                    <Toggle
+                      label="Extra rows"
+                      value={extraRows}
+                      disabledOn={clientOnlyReason}
+                      onChange={(next) => customize(setExtraRows, next)}
+                    />
+                    <Toggle
+                      label="Row style"
+                      value={rowStyle}
+                      disabledOn={clientOnlyReason}
+                      onChange={(next) => customize(setRowStyle, next)}
+                    />
+                  </ControlPanel>
+                </aside>
+              </>
+            }
+            activeFilterCount={recipe === "baseline" && locale === "en" ? 0 : 1}
+            onClearFilters={resetOptions}
+            labels={FEATURE_LAB_DRAWER_LABELS}
+          />
+        </MantineProvider>
 
         <div className="lab-preview">
           <div className="lab-summary" role="status">

--- a/apps/showcase/src/data.tsx
+++ b/apps/showcase/src/data.tsx
@@ -548,7 +548,6 @@ export function makeColumns(
       editable: true,
       editor: "number",
       editValue: (r) => String(budget(r)),
-      align: "end",
       width: 130,
       mobileLabel: s.budget,
     },
@@ -703,7 +702,6 @@ export function makeWideColumns(
       editable: true,
       editor: "number",
       editValue: (r) => String(budget(r)),
-      align: "end",
       width: 150,
     },
     {

--- a/apps/showcase/src/styles.css
+++ b/apps/showcase/src/styles.css
@@ -483,8 +483,7 @@ a {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.lab-config-trigger,
-.lab-drawer__close {
+.lab-config-trigger {
   flex: none;
   min-height: 36px;
   padding: 0 12px;
@@ -497,57 +496,17 @@ a {
   font-size: 13px;
   font-weight: 650;
 }
-.lab-config-trigger:hover,
-.lab-drawer__close:hover {
+.lab-config-trigger:hover {
   border-color: color-mix(in srgb, var(--brand) 45%, var(--page-border));
 }
 .lab-layout {
   margin-top: 10px;
   min-width: 0;
 }
-.lab-drawer {
-  inset-block: 12px;
-  inset-inline: auto 12px;
-  width: min(420px, calc(100vw - 24px));
-  height: calc(100dvh - 24px);
-  max-width: none;
-  max-height: none;
-  margin: 0;
-  padding: 0;
-  color: var(--ink);
-  background: var(--page-surface);
-  border: 1px solid var(--page-border);
-  border-radius: 16px;
-  box-shadow: 0 24px 80px oklch(0 0 0 / 0.28);
-  overflow: hidden;
-}
-.lab-drawer[open] {
-  display: flex;
-  flex-direction: column;
-}
-.lab-drawer::backdrop {
-  background: oklch(0.08 0.015 264 / 0.38);
-  backdrop-filter: blur(2px);
-}
-.lab-drawer__head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 14px 16px;
-  border-bottom: 1px solid var(--page-border);
-}
-.lab-drawer__head > div {
-  display: grid;
-  gap: 2px;
-  min-width: 0;
-}
-.lab-drawer__head strong {
-  font-size: 14px;
-}
-.lab-drawer__head span {
+.lab-options-drawer__intro {
+  margin: 0 0 12px;
   color: var(--ink-3);
-  font-size: 11px;
+  font-size: 12px;
 }
 .opt-board {
   display: grid;
@@ -555,10 +514,9 @@ a {
   margin: 0;
   min-width: 0;
 }
-.lab-drawer .opt-board {
-  padding: 12px;
-  overflow-y: auto;
-  overscroll-behavior: contain;
+.opt-board.lab-options-drawer__controls {
+  grid-template-columns: 1fr;
+  padding-bottom: 16px;
 }
 .opt-panel {
   min-width: 0;
@@ -884,27 +842,21 @@ a {
   .demo-live-update button {
     min-height: 40px;
   }
-  .lab-drawer {
-    inset-block: 8px;
-    inset-inline: 8px;
-    width: auto;
-    height: calc(100dvh - 16px);
-  }
-  .lab-drawer .opt-panel__row {
+  .lab-options-drawer__controls .opt-panel__row {
     display: grid;
     grid-template-columns: minmax(0, 1fr);
     align-items: stretch;
   }
-  .lab-drawer .ctrl {
+  .lab-options-drawer__controls .ctrl {
     align-items: stretch;
     flex-direction: column;
     gap: 5px;
   }
-  .lab-drawer .seg {
+  .lab-options-drawer__controls .seg {
     display: flex;
     width: 100%;
   }
-  .lab-drawer .seg__btn {
+  .lab-options-drawer__controls .seg__btn {
     flex: 1;
     justify-content: center;
     min-width: 0;

--- a/docs/api.md
+++ b/docs/api.md
@@ -1056,11 +1056,12 @@ the shared locale-resolution algorithm (see [i18n & RTL](./i18n-rtl.md)).
   re-exports); Radix and Base UI export their accent unions
   (`RadixAccentColor`, `BaseUiAccentColor`); Mantine also exports its
   chrome as reusable components (`ActiveFilterChips`, `AutoFilterForm`,
-  `EmptyState`, `ErrorState`, `PaginationFooter`, `TableSkeleton`, each
-  with a `…Props` companion: `ActiveFilterChipsProps`,
-  `AutoFilterFormProps`, `EmptyStateProps`, `ErrorStateProps`,
-  `PaginationFooterProps`, `TableSkeletonProps`); unstyled and shadcn
-  export their building blocks (`FilterPanel` / `FilterPanelProps`,
+  `EmptyState`, `ErrorState`, `FilterDrawer`, `PaginationFooter`,
+  `TableSkeleton`, each with a `…Props` companion:
+  `ActiveFilterChipsProps`, `AutoFilterFormProps`, `EmptyStateProps`,
+  `ErrorStateProps`, `FilterDrawerProps`, `PaginationFooterProps`,
+  `TableSkeletonProps`); unstyled and shadcn export their building blocks
+  (`FilterPanel` / `FilterPanelProps`,
   `FilterPopover` / `FilterPopoverProps`, `AutoFilterForm`, the `cx`
   class joiner) and shadcn additionally ships `shadcnClassNames`, the
   preset map behind its default look.

--- a/e2e/all-options.spec.ts
+++ b/e2e/all-options.spec.ts
@@ -55,6 +55,35 @@ test("all-options page loads grouped controls and the table", async ({
   ).toBeVisible();
 });
 
+test("Feature Lab options open as an edge drawer and close from its backdrop", async ({
+  page,
+}) => {
+  await page.goto("/all-options/");
+  await openFeatureControls(page);
+
+  const viewport = page.viewportSize();
+  const drawer = page.getByRole("dialog", { name: "Configure Feature Lab" });
+  await expect
+    .poll(async () => {
+      const box = await drawer.boundingBox();
+      return Math.abs(
+        (box?.x ?? 0) + (box?.width ?? 0) - (viewport?.width ?? 0)
+      );
+    })
+    .toBeLessThanOrEqual(1);
+  const panel = await drawer.boundingBox();
+  expect(viewport).not.toBeNull();
+  expect(panel).not.toBeNull();
+  expect(panel?.y).toBe(0);
+  expect(panel?.height).toBe(viewport?.height);
+
+  await page.mouse.click(8, Math.round((viewport?.height ?? 0) / 2));
+  await expect(drawer).toBeHidden();
+  await expect(
+    page.getByRole("button", { name: "Configure options" })
+  ).toHaveAttribute("aria-expanded", "false");
+});
+
 test("Feature Lab keeps its URL state separate from the live demo", async ({
   page,
 }) => {

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6515,11 +6515,12 @@ the shared locale-resolution algorithm (see [i18n & RTL](./i18n-rtl.md)).
   re-exports); Radix and Base UI export their accent unions
   (`RadixAccentColor`, `BaseUiAccentColor`); Mantine also exports its
   chrome as reusable components (`ActiveFilterChips`, `AutoFilterForm`,
-  `EmptyState`, `ErrorState`, `PaginationFooter`, `TableSkeleton`, each
-  with a `…Props` companion: `ActiveFilterChipsProps`,
-  `AutoFilterFormProps`, `EmptyStateProps`, `ErrorStateProps`,
-  `PaginationFooterProps`, `TableSkeletonProps`); unstyled and shadcn
-  export their building blocks (`FilterPanel` / `FilterPanelProps`,
+  `EmptyState`, `ErrorState`, `FilterDrawer`, `PaginationFooter`,
+  `TableSkeleton`, each with a `…Props` companion:
+  `ActiveFilterChipsProps`, `AutoFilterFormProps`, `EmptyStateProps`,
+  `ErrorStateProps`, `FilterDrawerProps`, `PaginationFooterProps`,
+  `TableSkeletonProps`); unstyled and shadcn export their building blocks
+  (`FilterPanel` / `FilterPanelProps`,
   `FilterPopover` / `FilterPopoverProps`, `AutoFilterForm`, the `cx`
   class joiner) and shadcn additionally ships `shadcnClassNames`, the
   preset map behind its default look.

--- a/packages/adapter-mantine/src/index.ts
+++ b/packages/adapter-mantine/src/index.ts
@@ -32,6 +32,10 @@ export { EmptyState, type EmptyStateProps } from "./components/EmptyState";
 export { ErrorState, type ErrorStateProps } from "./components/ErrorState";
 export { FillHandle } from "./components/FillHandle";
 export {
+  FilterDrawer,
+  type FilterDrawerProps,
+} from "./components/FilterDrawer";
+export {
   FilterTreeBuilder,
   type FilterTreeBuilderProps,
 } from "./components/FilterTreeBuilder";


### PR DESCRIPTION
## Summary
- reuse the Mantine adapter's exact `FilterDrawer` for Feature Lab options, including native enter/exit motion, backdrop dismissal, Reset, and Done actions
- keep the table preview full-width and align Budget with the other showcase columns
- document the adapter-owned Chrome + slots contract and add browser coverage for drawer geometry and outside-click closing

## Test plan
- [x] `pnpm check`
- [x] `pnpm --filter @adapttable/mantine typecheck`
- [x] `pnpm --filter @adapttable/showcase typecheck`
- [x] `pnpm exec playwright test e2e/all-options.spec.ts --grep \"edge drawer\"`
- [x] browser verification of forward/reverse drawer transitions, outside click, and Budget alignment across all eight adapters

## Release
No changeset by maintainer direction; this PR should not request a package version or publish.

Made with [Cursor](https://cursor.com)