### PR TITLE
fix: skip empty Release runs and close the leftover CI gaps

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,7 @@ concurrency:
 
 permissions:
   contents: read
+  pull-requests: read
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -39,8 +40,6 @@ jobs:
       needBuild: ${{ steps.flags.outputs.needBuild }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
 
       - name: Dedupe against PR-verified trees
         id: dedupe
@@ -70,6 +69,8 @@ jobs:
           EVENT: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
           BEFORE: ${{ github.event.before }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -o pipefail
           zero="0000000000000000000000000000000000000000"
@@ -96,8 +97,8 @@ jobs:
           echo "skipAll=false" >> "$GITHUB_OUTPUT"
           tmp="$(mktemp)"
           if [ "$EVENT" = "pull_request" ]; then
-            git fetch --quiet origin "$BASE_REF"
-            git diff --name-only "origin/$BASE_REF"...HEAD > "$tmp" || true
+            gh api --paginate "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \
+              --jq '.[].filename' > "$tmp"
             if ! emit "$tmp"; then
               echo "Could not classify the diff — fail-open to the full gate."
               node scripts/ci-detect.mjs >> "$GITHUB_OUTPUT"
@@ -105,6 +106,7 @@ jobs:
             exit 0
           fi
           if [ "$EVENT" = "push" ] && [ -n "$BEFORE" ] && [ "$BEFORE" != "$zero" ]; then
+            git fetch --no-tags --depth=1 origin "$BEFORE"
             git diff --name-only "$BEFORE" HEAD > "$tmp" || true
             emit "$tmp"
             exit 0

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,6 +35,7 @@ jobs:
       runPlaywright: ${{ steps.flags.outputs.runPlaywright }}
       runBench: ${{ steps.flags.outputs.runBench }}
       runPreview: ${{ steps.flags.outputs.runPreview }}
+      runKitsDocs: ${{ steps.flags.outputs.runKitsDocs }}
       needBuild: ${{ steps.flags.outputs.needBuild }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -88,6 +89,7 @@ jobs:
             echo "runPlaywright=false" >> "$GITHUB_OUTPUT"
             echo "runBench=false" >> "$GITHUB_OUTPUT"
             echo "runPreview=false" >> "$GITHUB_OUTPUT"
+            echo "runKitsDocs=false" >> "$GITHUB_OUTPUT"
             echo "needBuild=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -146,6 +148,10 @@ jobs:
         if: needs.detect.outputs.skipAll != 'true'
         run: pnpm check:docsurface
 
+      - name: Check the root README lists every CLI kit
+        if: needs.detect.outputs.runKitsDocs == 'true'
+        run: pnpm check:kits-docs
+
       - name: Test root tooling
         if: needs.detect.outputs.skipAll != 'true'
         run: pnpm test:scripts
@@ -160,7 +166,7 @@ jobs:
 
   eslint:
     name: ESLint
-    needs: [detect, build]
+    needs: detect
     if: needs.detect.outputs.skipAll != 'true' && needs.detect.outputs.runLint == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -187,7 +193,7 @@ jobs:
 
   typescript:
     name: TypeScript
-    needs: [detect, build]
+    needs: detect
     if: needs.detect.outputs.skipAll != 'true' && needs.detect.outputs.runLint == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -377,7 +383,6 @@ jobs:
 
   preview:
     name: Preview
-    continue-on-error: true
     needs: [detect, build]
     if: >
       github.event_name == 'pull_request' &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,28 @@ jobs:
       - id: check
         run: echo "enabled=${{ secrets.NPM_TOKEN != '' }}" >> "$GITHUB_OUTPUT"
 
-  release:
+  detect:
+    name: Detect
     needs: guard
     if: ${{ needs.guard.outputs.enabled == 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      needVersion: ${{ steps.flags.outputs.needVersion }}
+      needPublish: ${{ steps.flags.outputs.needPublish }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - id: flags
+        name: Classify version vs publish vs skip
+        run: node scripts/release-detect.mjs >> "$GITHUB_OUTPUT"
+
+  release:
+    needs: [guard, detect]
+    if: >
+      needs.guard.outputs.enabled == 'true' &&
+      (needs.detect.outputs.needVersion == 'true' ||
+       needs.detect.outputs.needPublish == 'true')
     name: Version or Publish
     runs-on: ubuntu-latest
     # contents: tag and commit the version bump · id-token: npm provenance on
@@ -58,12 +77,10 @@ jobs:
       - name: Create release PR or publish
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
-          # Publish does not re-run the full test gate — the PR that landed
-          # the code already did, and a version-only PR is publint + format.
-          # This path builds and publishes; publint is the last cheap check.
-          # ONE command: the action execs its publish input without a shell,
-          # so a `&&` here would be passed to pnpm as a literal argument. The
-          # gate-then-publish chain lives inside the release:gated script.
+          # Detect already decided a version PR or an unpublished package
+          # exists. Publish is build → publint → changeset publish — not
+          # verify:release. ONE command: the action execs its publish input
+          # without a shell, so a `&&` here would be a literal argument.
           publish: pnpm release:gated
           version: pnpm version-packages
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,9 @@ coverage where visual · tests with the coverage floors met.
    versions; exact pins resolve core automatically.
 
 Release mechanics: merge the PR carrying its changeset → the bot opens a
-"Version Packages" PR → merging that publishes to npm.
+"Version Packages" PR → merging that publishes to npm. A main push with
+neither a pending changeset nor an unpublished version skips the Release
+job; publish is build → publint → `changeset publish`, not `verify:release`.
 
 ## Generated vs hand-written files
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![npm version](https://img.shields.io/npm/v/@adapttable/core.svg)](https://www.npmjs.com/package/@adapttable/core)
 [![downloads](https://img.shields.io/npm/dm/@adapttable/core.svg)](https://www.npmjs.com/package/@adapttable/core)
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
-[![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178C6.svg)](https://www.typescriptlang.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178C6.svg)](./tsconfig.base.json)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](./CONTRIBUTING.md)
 
 **[🌐 Website](https://orwa-mahmoud.github.io/adapttable/)** · **[🚀 Live demo](https://orwa-mahmoud.github.io/adapttable/demo/)** · **[📖 Docs](https://orwa-mahmoud.github.io/adapttable/getting-started/)** · **[📦 npm](https://www.npmjs.com/org/adapttable)** · **[Compare](https://orwa-mahmoud.github.io/adapttable/comparison/)**

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "check": "pnpm run format:check && pnpm run lint && pnpm run lint:root && pnpm run check:readmes && pnpm run check:docsurface && pnpm run check:parts && pnpm run typecheck && pnpm run test:coverage && pnpm run test:scripts && pnpm run build && pnpm run publint && pnpm run smoke:dist && pnpm run budget",
     "prepare": "husky",
     "check:kits-docs": "pnpm --filter @adapttable/cli exec vitest run src/kits-docs.test.ts",
+    "check:readmes": "node scripts/check-readme-features.mjs",
     "check:sitemap": "node scripts/check-sitemap.mjs",
     "check:docsurface": "node scripts/check-doc-surface.mjs",
     "consumer:harness": "node scripts/consumer-harness.mjs",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "budget": "node scripts/bundle-budget.mjs",
     "check": "pnpm run format:check && pnpm run lint && pnpm run lint:root && pnpm run check:readmes && pnpm run check:docsurface && pnpm run check:parts && pnpm run typecheck && pnpm run test:coverage && pnpm run test:scripts && pnpm run build && pnpm run publint && pnpm run smoke:dist && pnpm run budget",
     "prepare": "husky",
-    "check:readmes": "node scripts/check-readme-features.mjs",
+    "check:kits-docs": "pnpm --filter @adapttable/cli exec vitest run src/kits-docs.test.ts",
     "check:sitemap": "node scripts/check-sitemap.mjs",
     "check:docsurface": "node scripts/check-doc-surface.mjs",
     "consumer:harness": "node scripts/consumer-harness.mjs",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "consumer:harness": "node scripts/consumer-harness.mjs",
     "api:reports": "node scripts/api-reports.mjs --local",
     "api:check": "node scripts/api-reports.mjs",
-    "release:gated": "pnpm run publint && pnpm run release",
+    "release:gated": "pnpm run build && pnpm run publint && changeset publish",
     "check:parts": "node scripts/check-parts-parity.mjs"
   },
   "devDependencies": {

--- a/scripts/check-if-needed.mjs
+++ b/scripts/check-if-needed.mjs
@@ -46,6 +46,9 @@ export function checkPlan(flags) {
 
   steps.push({ label: "check:readmes", args: ["run", "check:readmes"] });
   steps.push({ label: "check:docsurface", args: ["run", "check:docsurface"] });
+  if (flags.runKitsDocs) {
+    steps.push({ label: "check:kits-docs", args: ["run", "check:kits-docs"] });
+  }
 
   if (flags.runUnit) {
     steps.push({ label: "check:parts", args: ["run", "check:parts"] });

--- a/scripts/check-if-needed.test.mjs
+++ b/scripts/check-if-needed.test.mjs
@@ -14,6 +14,7 @@ describe("checkPlan", () => {
       "format:check",
       "check:readmes",
       "check:docsurface",
+      "check:kits-docs",
       "test:scripts",
     ]);
     assert.equal(checkReason(classify(["README.md"])), "docs/meta-only");
@@ -99,6 +100,7 @@ describe("checkPlan", () => {
       "lint:root",
       "check:readmes",
       "check:docsurface",
+      "check:kits-docs",
       "test:scripts",
     ]);
     assert.equal(checkReason(classify(files)), "root tooling");

--- a/scripts/ci-detect.mjs
+++ b/scripts/ci-detect.mjs
@@ -36,25 +36,30 @@ const VITEST_SHARED = /^vitest\.shared\.ts$/;
  *   runPlaywright: boolean,
  *   runBench: boolean,
  *   runPreview: boolean,
+ *   runKitsDocs: boolean,
  *   needBuild: boolean,
  *   versionOnly: boolean,
  * }}
  */
 export function classify(files) {
   const list = files.map((f) => f.trim()).filter(Boolean);
+  const readme = list.some((f) => f === "README.md");
 
   if (list.length === 0) {
-    return gate({
-      runLint: true,
-      runLintRoot: true,
-      runUnit: true,
-      runPackage: true,
-      runPublint: true,
-      runPlaywright: true,
-      runBench: true,
-      runPreview: true,
-      versionOnly: false,
-    });
+    return gate(
+      {
+        runLint: true,
+        runLintRoot: true,
+        runUnit: true,
+        runPackage: true,
+        runPublint: true,
+        runPlaywright: true,
+        runBench: true,
+        runPreview: true,
+        versionOnly: false,
+      },
+      { readme: false }
+    );
   }
 
   const packagesChanged = list.some((f) => PACKAGES.test(f));
@@ -69,51 +74,60 @@ export function classify(files) {
     list.every((f) => DOCS_OR_META.test(f) && !PACKAGES.test(f));
 
   if (docsOnly) {
-    return gate({
-      runLint: false,
-      runLintRoot: false,
-      runUnit: false,
-      runPackage: false,
-      runPublint: false,
-      runPlaywright: false,
-      runBench: false,
-      runPreview: false,
-      versionOnly: false,
-    });
+    return gate(
+      {
+        runLint: false,
+        runLintRoot: false,
+        runUnit: false,
+        runPackage: false,
+        runPublint: false,
+        runPlaywright: false,
+        runBench: false,
+        runPreview: false,
+        versionOnly: false,
+      },
+      { readme }
+    );
   }
 
   if (versionOnly) {
-    return gate({
-      runLint: false,
-      runLintRoot: false,
-      runUnit: false,
-      runPackage: false,
-      runPublint: true,
-      runPlaywright: false,
-      runBench: false,
-      runPreview: false,
-      versionOnly: true,
-    });
+    return gate(
+      {
+        runLint: false,
+        runLintRoot: false,
+        runUnit: false,
+        runPackage: false,
+        runPublint: true,
+        runPlaywright: false,
+        runBench: false,
+        runPreview: false,
+        versionOnly: true,
+      },
+      { readme }
+    );
   }
 
-  return gate({
-    runLint: packagesChanged || eslintRoot,
-    runLintRoot: packagesChanged || rootTooling,
-    runUnit: packagesChanged || vitestShared,
-    runPackage: packagesChanged,
-    runPublint: packagesChanged,
-    runPlaywright: playwright,
-    runBench: bench,
-    runPreview: packagesChanged,
-    versionOnly: false,
-  });
+  return gate(
+    {
+      runLint: packagesChanged || eslintRoot,
+      runLintRoot: packagesChanged || rootTooling,
+      runUnit: packagesChanged || vitestShared,
+      runPackage: packagesChanged,
+      runPublint: packagesChanged,
+      runPlaywright: playwright,
+      runBench: bench,
+      runPreview: packagesChanged,
+      versionOnly: false,
+    },
+    { readme }
+  );
 }
 
-function gate(flags) {
+function gate(flags, { readme = false } = {}) {
   return {
     ...flags,
-    needBuild:
-      flags.runLint || flags.runUnit || flags.runPackage || flags.runPublint,
+    runKitsDocs: Boolean(readme && !flags.runUnit),
+    needBuild: flags.runUnit || flags.runPackage || flags.runPublint,
   };
 }
 

--- a/scripts/ci-detect.test.mjs
+++ b/scripts/ci-detect.test.mjs
@@ -18,6 +18,7 @@ describe("classify", () => {
     assert.equal(f.runPackage, false);
     assert.equal(f.runPreview, false);
     assert.equal(f.runPlaywright, false);
+    assert.equal(f.runKitsDocs, true);
     assert.equal(f.needBuild, false);
   });
 
@@ -27,6 +28,7 @@ describe("classify", () => {
     assert.equal(f.runUnit, false);
     assert.equal(f.runPlaywright, false);
     assert.equal(f.needBuild, false);
+    assert.equal(f.runKitsDocs, false);
   });
 
   it("does not lint adapters for a workflow-only change", () => {
@@ -52,6 +54,7 @@ describe("classify", () => {
     assert.equal(f.runPreview, false);
     assert.equal(f.runPlaywright, false);
     assert.equal(f.runLintRoot, true);
+    assert.equal(f.runKitsDocs, true);
     assert.equal(f.needBuild, false);
   });
 
@@ -77,6 +80,7 @@ describe("classify", () => {
     assert.equal(f.runPreview, true);
     assert.equal(f.runPlaywright, true);
     assert.equal(f.runBench, true);
+    assert.equal(f.runKitsDocs, false);
   });
 
   it("runs Playwright when only e2e specs change, not the packed harness", () => {
@@ -93,7 +97,7 @@ describe("classify", () => {
     assert.equal(f.runLint, true);
     assert.equal(f.runLintRoot, true);
     assert.equal(f.runUnit, false);
-    assert.equal(f.needBuild, true);
+    assert.equal(f.needBuild, false);
   });
 
   it("runs unit shards when the shared vitest config changes", () => {

--- a/scripts/release-detect.mjs
+++ b/scripts/release-detect.mjs
@@ -1,0 +1,125 @@
+/**
+ * Decide whether a main-push Release job should version, publish, or skip.
+ * Pending changesets open a Version PR. Unpublished package versions (or a
+ * failed registry lookup) run build → publint → changeset publish. Otherwise
+ * the workflow exits without installing the library toolchain.
+ */
+
+/**
+ * @typedef {{ name: string, version: string }} Publishable
+ * @typedef {{
+ *   needVersion: boolean,
+ *   needPublish: boolean,
+ *   reason: string,
+ * }} ReleasePlan
+ */
+
+/**
+ * Changeset notes are `*.md` files in `.changeset/`. The folder README is not
+ * a pending release.
+ *
+ * @param {string[]} files
+ * @returns {string[]}
+ */
+export function pendingChangesets(files) {
+  return files.filter((f) => f.endsWith(".md") && f !== "README.md");
+}
+
+/**
+ * @param {{
+ *   changesetFiles: string[],
+ *   packages: Publishable[],
+ *   published: Record<string, string | null | undefined>,
+ * }} input `published[name]` is the registry latest, `null` if the package
+ *   was never published, `undefined` if the lookup failed.
+ * @returns {ReleasePlan}
+ */
+export function classifyRelease({ changesetFiles, packages, published }) {
+  if (pendingChangesets(changesetFiles).length > 0) {
+    return {
+      needVersion: true,
+      needPublish: false,
+      reason: "pending changesets",
+    };
+  }
+
+  const unpublished = packages.filter((p) => published[p.name] !== p.version);
+  if (unpublished.length === 0) {
+    return {
+      needVersion: false,
+      needPublish: false,
+      reason: "nothing to version or publish",
+    };
+  }
+
+  const lookupFailed = unpublished.some((p) => published[p.name] === undefined);
+  return {
+    needVersion: false,
+    needPublish: true,
+    reason: lookupFailed
+      ? "registry lookup failed — fail-open to publish"
+      : "unpublished versions",
+  };
+}
+
+function printPlan(plan) {
+  process.stdout.write(
+    `needVersion=${plan.needVersion}\nneedPublish=${plan.needPublish}\n`
+  );
+  process.stderr.write(`release-detect: ${plan.reason}\n`);
+}
+
+const invokedDirectly = process.argv[1]?.endsWith("release-detect.mjs");
+if (invokedDirectly) {
+  const { readdir, readFile } = await import("node:fs/promises");
+  const { join, dirname } = await import("node:path");
+  const { fileURLToPath } = await import("node:url");
+
+  const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const changesetDir = join(root, ".changeset");
+  const config = JSON.parse(
+    await readFile(join(changesetDir, "config.json"), "utf8")
+  );
+  const ignored = new Set(config.ignore ?? []);
+  const changesetFiles = await readdir(changesetDir);
+  const pkgDirs = await readdir(join(root, "packages"), {
+    withFileTypes: true,
+  });
+  /** @type {Publishable[]} */
+  const packages = [];
+  for (const ent of pkgDirs) {
+    if (!ent.isDirectory()) continue;
+    const pkg = JSON.parse(
+      await readFile(join(root, "packages", ent.name, "package.json"), "utf8")
+    );
+    if (pkg.private || ignored.has(pkg.name) || !pkg.name || !pkg.version) {
+      continue;
+    }
+    packages.push({ name: pkg.name, version: pkg.version });
+  }
+
+  /** @type {Record<string, string | null | undefined>} */
+  const published = {};
+  await Promise.all(
+    packages.map(async (p) => {
+      try {
+        const url = `https://registry.npmjs.org/${encodeURIComponent(p.name)}`;
+        const res = await fetch(url);
+        if (res.status === 404) {
+          published[p.name] = null;
+          return;
+        }
+        if (!res.ok) {
+          published[p.name] = undefined;
+          return;
+        }
+        const body = await res.json();
+        published[p.name] = body["dist-tags"]?.latest ?? null;
+      } catch {
+        published[p.name] = undefined;
+      }
+    })
+  );
+
+  printPlan(classifyRelease({ changesetFiles, packages, published }));
+}

--- a/scripts/release-detect.test.mjs
+++ b/scripts/release-detect.test.mjs
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { classifyRelease, pendingChangesets } from "./release-detect.mjs";
+
+describe("pendingChangesets", () => {
+  it("ignores the folder README and non-markdown files", () => {
+    assert.deepEqual(
+      pendingChangesets(["README.md", "config.json", "cool-fish.md"]),
+      ["cool-fish.md"]
+    );
+  });
+});
+
+describe("classifyRelease", () => {
+  const core = { name: "@adapttable/core", version: "2.6.0" };
+
+  it("opens a Version PR when a changeset is pending, even if npm matches", () => {
+    const plan = classifyRelease({
+      changesetFiles: ["README.md", "neat-fox.md"],
+      packages: [core],
+      published: { "@adapttable/core": "2.6.0" },
+    });
+    assert.equal(plan.needVersion, true);
+    assert.equal(plan.needPublish, false);
+  });
+
+  it("skips when nothing is pending and every version is on npm", () => {
+    const plan = classifyRelease({
+      changesetFiles: ["README.md"],
+      packages: [core],
+      published: { "@adapttable/core": "2.6.0" },
+    });
+    assert.equal(plan.needVersion, false);
+    assert.equal(plan.needPublish, false);
+    assert.equal(plan.reason, "nothing to version or publish");
+  });
+
+  it("publishes when a package version is not the registry latest", () => {
+    const plan = classifyRelease({
+      changesetFiles: ["README.md"],
+      packages: [core],
+      published: { "@adapttable/core": "2.5.0" },
+    });
+    assert.equal(plan.needVersion, false);
+    assert.equal(plan.needPublish, true);
+    assert.equal(plan.reason, "unpublished versions");
+  });
+
+  it("publishes a never-published package", () => {
+    const plan = classifyRelease({
+      changesetFiles: [],
+      packages: [core],
+      published: { "@adapttable/core": null },
+    });
+    assert.equal(plan.needPublish, true);
+  });
+
+  it("fail-opens to publish when the registry lookup failed", () => {
+    const plan = classifyRelease({
+      changesetFiles: ["README.md"],
+      packages: [core],
+      published: { "@adapttable/core": undefined },
+    });
+    assert.equal(plan.needPublish, true);
+    assert.match(plan.reason, /fail-open/);
+  });
+});


### PR DESCRIPTION
## Summary
- Release Detect skips version/publish unless there is a pending changeset or an unpublished npm version. Publish order is build → publint → `changeset publish` (not `verify:release`).
- README still runs the one-file CLI kits-docs guard, not the library gate. ESLint and TypeScript no longer wait on Build. TypeScript badge points at `tsconfig.base.json`. Preview is a real job now that pkg-pr-new is installed.

## Test plan
- [ ] Detect + Format (+ kits-docs) + four wrap-ups go green; adapter lint/unit/package/Playwright stay skipped
- [ ] Release Detect on this merge would skip Version or Publish (no changeset, versions already on npm)


Made with [Cursor](https://cursor.com)