### PR TITLE
feat: ask for a GitHub star on the live demo

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,8 @@
 name: CodeQL
 
+# Pull requests are scanned in pr.yml. This workflow is the weekly
+# full-repo pass only — not a second scan on every merge to main.
 on:
-  push:
-    branches: [main]
   schedule:
     # Weekly re-scan so newly published queries run against unchanged code.
     - cron: "17 3 * * 1"

--- a/apps/showcase/src/PageShell.tsx
+++ b/apps/showcase/src/PageShell.tsx
@@ -4,6 +4,7 @@ import { type ReactNode, startTransition, useEffect, useState } from "react";
 
 import { DEMO_CONFIRM_EVENT, DEMO_NOTICE_EVENT, type DemoNotice } from "./data";
 import { AppNav, Footer } from "./sections";
+import { StarTheRepo } from "./StarTheRepo";
 
 const queryClient = new QueryClient();
 
@@ -83,6 +84,7 @@ export function PageShell({
         }}
       />
       <main>{children(dark)}</main>
+      <StarTheRepo />
       <Footer root={root} />
 
       {notice && (

--- a/apps/showcase/src/StarTheRepo.tsx
+++ b/apps/showcase/src/StarTheRepo.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from "react";
+
+const DISMISS_KEY = "adapttable-star-the-repo";
+const START_KEY = "adapttable-star-the-repo-since";
+const CLOSED_KEY = "adapttable-star-the-repo-closed";
+const DELAY_MS = 20_000;
+const REPO = "https://github.com/orwa-mahmoud/adapttable";
+
+const readDismissed = (): boolean => {
+  try {
+    return window.localStorage.getItem(DISMISS_KEY) === "1";
+  } catch {
+    return true;
+  }
+};
+
+const persistDismissed = (): void => {
+  try {
+    window.localStorage.setItem(DISMISS_KEY, "1");
+  } catch {
+    // Private mode: the prompt will not survive a reload anyway.
+  }
+};
+
+const readClosed = (): boolean => {
+  try {
+    return window.sessionStorage.getItem(CLOSED_KEY) === "1";
+  } catch {
+    return false;
+  }
+};
+
+const persistClosed = (): void => {
+  try {
+    window.sessionStorage.setItem(CLOSED_KEY, "1");
+  } catch {
+    // Session storage can be unavailable — closing still hides it this page.
+  }
+};
+
+/** First demo-page visit in this tab. Survives MPA navigations. */
+const readStart = (): number => {
+  try {
+    const raw = window.sessionStorage.getItem(START_KEY);
+    if (raw) {
+      const n = Number(raw);
+      if (Number.isFinite(n)) return n;
+    }
+    const now = Date.now();
+    window.sessionStorage.setItem(START_KEY, String(now));
+    return now;
+  } catch {
+    return Date.now();
+  }
+};
+
+/**
+ * Centered modal on the live demo: twenty elapsed seconds from the first
+ * demo page in this tab, then ask once for a GitHub star. Interaction is
+ * not required. It does not block the table. Close hides it for this tab;
+ * Don't show again or the star link writes localStorage and never shows
+ * again on this device until that key is cleared.
+ */
+export function StarTheRepo() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (readDismissed() || readClosed()) return;
+    if (navigator.webdriver) return;
+
+    const remaining = DELAY_MS - (Date.now() - readStart());
+    if (remaining <= 0) {
+      setOpen(true);
+      return;
+    }
+    const timer = window.setTimeout(() => setOpen(true), remaining);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  const close = () => {
+    persistClosed();
+    setOpen(false);
+  };
+
+  const dismissForever = () => {
+    persistDismissed();
+    persistClosed();
+    setOpen(false);
+  };
+
+  if (!open) return null;
+
+  return (
+    <section
+      className="star-the-repo"
+      role="dialog"
+      aria-labelledby="star-the-repo-title"
+    >
+      <button
+        type="button"
+        className="star-the-repo__close"
+        aria-label="Close"
+        onClick={close}
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 14 14"
+          aria-hidden="true"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.8"
+          strokeLinecap="round"
+        >
+          <path d="M2 2l10 10M12 2L2 12" />
+        </svg>
+      </button>
+      <h2 id="star-the-repo-title" className="star-the-repo__title">
+        Enjoying AdaptTable?
+      </h2>
+      <p className="star-the-repo__copy">
+        A GitHub star helps more developers discover it.
+      </p>
+      <div className="star-the-repo__actions">
+        <a
+          className="star-the-repo__star"
+          href={REPO}
+          target="_blank"
+          rel="noreferrer"
+          onClick={dismissForever}
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 16 16"
+            aria-hidden="true"
+            fill="currentColor"
+          >
+            <path d="M8 .25a.75.75 0 0 1 .673.418l1.882 3.815 4.21.612a.75.75 0 0 1 .416 1.279l-3.046 2.97.719 4.192a.751.751 0 0 1-1.088.791L8 12.347l-3.766 1.98a.75.75 0 0 1-1.088-.79l.72-4.194L.818 6.374a.75.75 0 0 1 .416-1.28l4.21-.611L7.327.668A.75.75 0 0 1 8 .25Z" />
+          </svg>
+          Star AdaptTable
+        </a>
+        <button
+          type="button"
+          className="star-the-repo__skip"
+          onClick={dismissForever}
+        >
+          Don&apos;t show again
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/apps/showcase/src/styles.css
+++ b/apps/showcase/src/styles.css
@@ -1364,3 +1364,110 @@ a {
   white-space: nowrap;
   border: 0;
 }
+
+/* StarTheRepo — centered modal after 20 elapsed seconds. No backdrop:
+   the table stays usable; close dismisses it. */
+.star-the-repo {
+  position: fixed;
+  z-index: 90;
+  left: 50%;
+  top: 50%;
+  translate: -50% -50%;
+  width: max-content;
+  max-width: calc(100vw - 40px);
+  padding: 24px;
+  border: 1px solid var(--page-border);
+  border-radius: 14px;
+  background: var(--page-surface);
+  color: var(--ink);
+  box-shadow: var(--shadow-card);
+}
+.star-the-repo__close {
+  position: absolute;
+  top: 8px;
+  inset-inline-end: 8px;
+  display: grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border: 0;
+  border-radius: 9px;
+  background: transparent;
+  color: var(--ink-3);
+  cursor: pointer;
+}
+.star-the-repo__close:hover {
+  color: var(--ink);
+}
+.star-the-repo__title {
+  margin: 0 0 8px;
+  padding-inline: 36px;
+  font-size: 18px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  text-align: center;
+  color: var(--ink);
+}
+.star-the-repo__copy {
+  margin: 0 0 18px;
+  font-size: 14px;
+  line-height: 1.45;
+  color: var(--ink-2);
+  white-space: nowrap;
+}
+.star-the-repo__actions {
+  display: flex;
+  flex-wrap: nowrap;
+  align-items: center;
+  justify-content: center;
+  gap: 14px;
+}
+.star-the-repo__star {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  min-height: 44px;
+  padding: 0 15px;
+  border-radius: 9px;
+  background: var(--ink);
+  color: var(--page-bg);
+  font-size: 14px;
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+  transition:
+    transform 0.15s,
+    opacity 0.15s;
+}
+.star-the-repo__star:hover {
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+.star-the-repo__skip {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  min-height: 28px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--ink-3);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.star-the-repo__skip:hover {
+  color: var(--ink-2);
+}
+@media (prefers-reduced-motion: reduce) {
+  .star-the-repo__star {
+    transition: none;
+  }
+  .star-the-repo__star:hover {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- After 20 seconds on the demo, show a centered **Star AdaptTable** modal that does not block the table.
- Close hides it for the tab; **Don’t show again** or starring writes `localStorage` and never shows again on that device.
- CodeQL stays on PRs and the Monday cron; it no longer runs on every merge to `main`.

## Test plan
- [ ] Open the demo, wait 20s with no interaction — modal appears.
- [ ] Close (×) — gone for this tab; a new visit another day shows it again.
- [ ] Don’t show again / Star AdaptTable — still gone after reload and after months unless site data is cleared.
- [ ] Switching demo pages does not reset the 20s clock.