### PR TITLE
fix: layout-stable landing nav and demo placeholder, precise window-error reporting

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -73,6 +73,11 @@ export default defineConfig({
                 tag: "script",
                 attrs: {
                   async: true,
+                  // googletagmanager.com serves the tag with
+                  // `access-control-allow-origin: *`, so an anonymous fetch
+                  // gives the browser full error detail instead of the opaque
+                  // "Script error." every cross-origin failure collapses into.
+                  crossorigin: "anonymous",
                   src: "https://www.googletagmanager.com/gtag/js?id=G-FT8LY7Z15Y",
                 },
               },
@@ -93,7 +98,22 @@ export default defineConfig({
                   "    });",
                   "  }",
                   "  window.addEventListener('error', function (event) {",
-                  "    report(event.error && event.error.name ? event.error.name : 'Error', true);",
+                  "    var message = typeof event.message === 'string' ? event.message : '';",
+                  // ResizeObserver's benign loop notification arrives as an
+                  // error event with no error object. It gets its own bucket so
+                  // the count stays readable in GA4 instead of hiding inside a
+                  // generic 'Error' total.
+                  "    if (message.startsWith('ResizeObserver loop')) {",
+                  "      report('ResizeObserverLoop', false);",
+                  "      return;",
+                  "    }",
+                  "    var error = event.error;",
+                  // Without an error object the message is the only identifying
+                  // detail GA4 will ever see, so send it instead of the blanket
+                  // 'Error' — truncated to the 100-character parameter limit.
+                  // Only a real error object marks the event fatal.
+                  "    var name = error && error.name ? error.name : '';",
+                  "    report(name || message.slice(0, 100) || 'Error', Boolean(error));",
                   "  });",
                   "  window.addEventListener('unhandledrejection', function (event) {",
                   "    report(event.reason && event.reason.name ? event.reason.name : 'UnhandledRejection', false);",

--- a/apps/docs/src/pages/index.astro
+++ b/apps/docs/src/pages/index.astro
@@ -169,8 +169,13 @@ const JSON_LD = JSON.stringify({
     {
       import.meta.env.PROD && (
         <>
+          {/* googletagmanager.com serves the tag with
+              `access-control-allow-origin: *`, so an anonymous fetch gives the
+              browser full error detail instead of the opaque "Script error."
+              every cross-origin failure collapses into. */}
           <script
             async
+            crossorigin="anonymous"
             src="https://www.googletagmanager.com/gtag/js?id=G-FT8LY7Z15Y"
           />
           <script
@@ -189,7 +194,20 @@ gtag('config', 'G-FT8LY7Z15Y');
     });
   }
   window.addEventListener('error', function (event) {
-    report(event.error && event.error.name ? event.error.name : 'Error', true);
+    var message = typeof event.message === 'string' ? event.message : '';
+    // ResizeObserver's benign loop notification arrives as an error event with
+    // no error object. It gets its own bucket so the count stays readable in
+    // GA4 instead of hiding inside a generic 'Error' total.
+    if (message.startsWith('ResizeObserver loop')) {
+      report('ResizeObserverLoop', false);
+      return;
+    }
+    var error = event.error;
+    // Without an error object the message is the only identifying detail GA4
+    // will ever see, so send it instead of the blanket 'Error' — truncated to
+    // the 100-character parameter limit. Only a real error object is fatal.
+    var name = error && error.name ? error.name : '';
+    report(name || message.slice(0, 100) || 'Error', Boolean(error));
   });
   window.addEventListener('unhandledrejection', function (event) {
     report(event.reason && event.reason.name ? event.reason.name : 'UnhandledRejection', false);

--- a/apps/docs/src/pages/index.astro
+++ b/apps/docs/src/pages/index.astro
@@ -992,6 +992,26 @@ gtag('config', 'G-FT8LY7Z15Y');
 </html>
 
 <style>
+  /* Schibsted Grotesk loads with `display=swap`, so the first paint uses a
+     local face and every glyph metric changes when the webfont arrives.
+     This face wraps the local fallback in Schibsted Grotesk's own metrics —
+     ascent 977/1000, descent 258/1000, no line gap — with `size-adjust`
+     carrying the 2.58% advance-width difference measured against Helvetica
+     and Arial, which share identical widths. Helvetica covers macOS, Arial
+     Windows, Liberation Sans the metric-compatible Linux clone; anywhere
+     none of the three exists the stack falls through to `system-ui` as
+     before. */
+  @font-face {
+    font-family: "Schibsted Grotesk Fallback";
+    src:
+      local("Helvetica"),
+      local("Arial"),
+      local("Liberation Sans");
+    size-adjust: 102.58%;
+    ascent-override: 95.24%;
+    descent-override: 25.15%;
+    line-gap-override: 0%;
+  }
   /* The demo's exact token set (light theme), so /demo and the landing
      read as one product. */
   :root {
@@ -1022,7 +1042,8 @@ gtag('config', 'G-FT8LY7Z15Y');
   body {
     margin: 0;
     /* The brand face, same as the demo's: Schibsted Grotesk. */
-    font-family: "Schibsted Grotesk", system-ui, sans-serif;
+    font-family:
+      "Schibsted Grotesk", "Schibsted Grotesk Fallback", system-ui, sans-serif;
     /* The demo's effective body line-height (Chakra's 1.5). */
     line-height: 1.5;
     background: var(--page-bg);
@@ -1089,17 +1110,44 @@ gtag('config', 'G-FT8LY7Z15Y');
     margin-inline-start: 14px;
   }
   .nav__links a {
+    position: relative;
     color: var(--ink-2);
     font-size: 14px;
     font-weight: 500;
     transition: color 0.15s;
+  }
+  /* The active marker is an absolutely positioned underline animated with
+     transform and opacity only. The scroll watcher retags the active link on
+     every section crossing, so anything that changes the link's metrics —
+     a heavier weight above all — reflows the sticky nav on every scroll. */
+  .nav__links a::after {
+    content: "";
+    position: absolute;
+    inset-inline: 0;
+    bottom: -7px;
+    height: 2px;
+    border-radius: 2px;
+    background: var(--brand);
+    opacity: 0;
+    transform: scaleX(0.3);
+    transition:
+      opacity 0.15s,
+      transform 0.15s;
   }
   .nav__links a:hover {
     color: var(--ink);
   }
   .nav__links a.is-on {
     color: var(--brand);
-    font-weight: 650;
+  }
+  .nav__links a.is-on::after {
+    opacity: 1;
+    transform: scaleX(1);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .nav__links a::after {
+      transition: none;
+    }
   }
   .nav__right {
     margin-inline-start: auto;

--- a/apps/showcase/src/styles.css
+++ b/apps/showcase/src/styles.css
@@ -734,7 +734,14 @@ a {
 .demo-surface__fallback {
   display: grid;
   place-items: center;
-  min-height: 280px;
+  /* Reserve what a mounted table occupies, so swapping this placeholder for
+     the real adapter chunk moves the page as little as possible. Measured
+     across all nine kits at 1280px the surface body settles at 463–580px,
+     clustered on 500px; 472px plus the body's 28px of padding lands on that
+     cluster. The mobile card layout runs 1562–2238px, but the surface sits
+     below the fold on a phone, so reserving that much would trade a shift
+     nobody sees for a screen and a half of empty placeholder. */
+  min-height: 472px;
   color: var(--ink-2);
   font-size: 14px;
 }

--- a/apps/showcase/vite.config.ts
+++ b/apps/showcase/vite.config.ts
@@ -31,6 +31,10 @@ const googleAnalytics = (): Plugin => ({
       tag: "script",
       attrs: {
         async: true,
+        // googletagmanager.com serves the tag with `access-control-allow-origin: *`,
+        // so an anonymous fetch gives the browser full error detail instead of
+        // the opaque "Script error." every cross-origin failure collapses into.
+        crossorigin: "anonymous",
         src: `https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`,
       },
       injectTo: "head",
@@ -52,7 +56,21 @@ const googleAnalytics = (): Plugin => ({
         "    });",
         "  }",
         "  window.addEventListener('error', function (event) {",
-        "    report(event.error && event.error.name ? event.error.name : 'Error', true);",
+        "    var message = typeof event.message === 'string' ? event.message : '';",
+        // ResizeObserver's benign loop notification arrives as an error event
+        // with no error object. It gets its own bucket so the count stays
+        // readable in GA4 instead of hiding inside a generic 'Error' total.
+        "    if (message.startsWith('ResizeObserver loop')) {",
+        "      report('ResizeObserverLoop', false);",
+        "      return;",
+        "    }",
+        "    var error = event.error;",
+        // Without an error object the message is the only identifying detail
+        // GA4 will ever see, so send it instead of the blanket 'Error' —
+        // truncated to the 100-character parameter limit. Only a real error
+        // object marks the event fatal.
+        "    var name = error && error.name ? error.name : '';",
+        "    report(name || message.slice(0, 100) || 'Error', Boolean(error));",
         "  });",
         "  window.addEventListener('unhandledrejection', function (event) {",
         "    report(event.reason && event.reason.name ? event.reason.name : 'UnhandledRejection', false);",

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -7,7 +7,7 @@ between [Mantine](https://orwa-mahmoud.github.io/adapttable/demo/?kit=mantine) Â
 [shadcn](https://orwa-mahmoud.github.io/adapttable/demo/?kit=shadcn) Â· [Tailwind](https://orwa-mahmoud.github.io/adapttable/demo/?kit=tailwind) on the same data,
 and toggle grouping and inline editing while you are there.
 
-<video src="https://orwa-mahmoud.github.io/adapttable/media/core/tour.mp4" poster="https://orwa-mahmoud.github.io/adapttable/media/core/poster.png?v=2" controls playsinline preload="none" style="width:100%;border-radius:8px"></video>
+<video src="https://orwa-mahmoud.github.io/adapttable/media/core/tour.mp4" poster="https://orwa-mahmoud.github.io/adapttable/media/core/poster.png?v=2" controls playsinline preload="none" width="1500" height="1065" style="width:100%;height:auto;aspect-ratio:1500/1065;border-radius:8px"></video>
 
 AdaptTable is a headless, UI-agnostic React data table. Pick the adapter for
 your design system and you get a styled, sortable, filterable, paginated

--- a/docs/mobile.md
+++ b/docs/mobile.md
@@ -2,7 +2,7 @@
 
 ▶ **See it before you install:** [the live mobile demo](https://orwa-mahmoud.github.io/adapttable/demo/mantine/mobile-cards/) — the same table flipped between desktop rows and phone cards with one toggle.
 
-[![The same AdaptTable data table as phone cards — scrolling the card list, then switching to the desktop table](https://orwa-mahmoud.github.io/adapttable/media/features/mobile.gif)](https://orwa-mahmoud.github.io/adapttable/demo/mantine/mobile-cards/)
+<a href="https://orwa-mahmoud.github.io/adapttable/demo/mantine/mobile-cards/"><img src="https://orwa-mahmoud.github.io/adapttable/media/features/mobile.gif" alt="The same AdaptTable data table as phone cards — scrolling the card list, then switching to the desktop table" width="640" height="392" style="width:100%;height:auto;aspect-ratio:640/392;border-radius:8px" /></a>
 
 Most React data tables answer the phone problem with a horizontal scrollbar.
 AdaptTable answers it with a different layout: below the mobile breakpoint,

--- a/e2e/pdf-export.spec.ts
+++ b/e2e/pdf-export.spec.ts
@@ -212,15 +212,14 @@ for (const [from, to] of REPLACED_PAGES) {
     });
 
     test("declares the new URL to a crawler without JavaScript", async ({
-      browser,
+      request,
     }) => {
-      const context = await browser.newContext({ javaScriptEnabled: false });
-      const page = await context.newPage();
-      // Meta-refresh still fires with scripting off, so take the response the
-      // moment it commits — a page that has already forwarded itself hands
-      // back the destination's bytes, or none at all.
-      const response = await page.goto(`/${from}/`, { waitUntil: "commit" });
-      const html = await response!.text();
+      // A crawler reads the stub's bytes without rendering anything, so fetch
+      // them the same way. A browser page races its own meta-refresh here:
+      // the stub forwards the moment it commits, and the original response
+      // body can be gone before it is read.
+      const response = await request.get(`/${from}/`);
+      const html = await response.text();
 
       expect(html).toContain('http-equiv="refresh"');
       expect(html).toContain(`${to}/`);
@@ -230,14 +229,15 @@ for (const [from, to] of REPLACED_PAGES) {
 
       // Not thin content: a stub carrying one line of text reads as a soft
       // 404, so it says what moved and where in real prose.
-      const words = (await page.locator("main").innerText()).split(
-        /\s+/
-      ).length;
+      const main = /<main[\s\S]*?<\/main>/.exec(html)?.[0] ?? "";
+      const words = main
+        .replace(/<[^>]+>/g, " ")
+        .trim()
+        .split(/\s+/).length;
       expect(words, `the stub serves only ${words} words`).toBeGreaterThan(40);
 
       // And it mounts no demo — the bundle belongs to the page that moved.
       expect(html).not.toContain("/src/entry-");
-      await context.close();
     });
   });
 }

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -14,7 +14,7 @@ between [Mantine](https://orwa-mahmoud.github.io/adapttable/demo/?kit=mantine) �
 [shadcn](https://orwa-mahmoud.github.io/adapttable/demo/?kit=shadcn) · [Tailwind](https://orwa-mahmoud.github.io/adapttable/demo/?kit=tailwind) on the same data,
 and toggle grouping and inline editing while you are there.
 
-<video src="https://orwa-mahmoud.github.io/adapttable/media/core/tour.mp4" poster="https://orwa-mahmoud.github.io/adapttable/media/core/poster.png?v=2" controls playsinline preload="none" style="width:100%;border-radius:8px"></video>
+<video src="https://orwa-mahmoud.github.io/adapttable/media/core/tour.mp4" poster="https://orwa-mahmoud.github.io/adapttable/media/core/poster.png?v=2" controls playsinline preload="none" width="1500" height="1065" style="width:100%;height:auto;aspect-ratio:1500/1065;border-radius:8px"></video>
 
 AdaptTable is a headless, UI-agnostic React data table. Pick the adapter for
 your design system and you get a styled, sortable, filterable, paginated
@@ -5251,7 +5251,7 @@ See it live in the [demo](https://orwa-mahmoud.github.io/adapttable/demo/).
 
 ▶ **See it before you install:** [the live mobile demo](https://orwa-mahmoud.github.io/adapttable/demo/mantine/mobile-cards/) — the same table flipped between desktop rows and phone cards with one toggle.
 
-[![The same AdaptTable data table as phone cards — scrolling the card list, then switching to the desktop table](https://orwa-mahmoud.github.io/adapttable/media/features/mobile.gif)](https://orwa-mahmoud.github.io/adapttable/demo/mantine/mobile-cards/)
+<a href="https://orwa-mahmoud.github.io/adapttable/demo/mantine/mobile-cards/"><img src="https://orwa-mahmoud.github.io/adapttable/media/features/mobile.gif" alt="The same AdaptTable data table as phone cards — scrolling the card list, then switching to the desktop table" width="640" height="392" style="width:100%;height:auto;aspect-ratio:640/392;border-radius:8px" /></a>
 
 Most React data tables answer the phone problem with a horizontal scrollbar.
 AdaptTable answers it with a different layout: below the mobile breakpoint,


### PR DESCRIPTION
## What changed

**Window-error reporting** — an `error` event with no error object now reports its
message, truncated to 100 characters, instead of the blanket `exception_type: 'Error'`;
messages starting with "ResizeObserver loop" get their own `ResizeObserverLoop` bucket;
`fatal` is true only when the event carries a real error object. Applied to all three
tags — the showcase Vite plugin, the Starlight head config and the landing page. The
gtag script loads with `crossorigin="anonymous"`.

**Landing page nav** — the active tab keeps a constant font-weight and reads as brand
colour plus an `::after` underline animated with transform and opacity only, so the
scroll watcher no longer reflows the sticky bar at every section crossing. A
`Schibsted Grotesk Fallback` face wraps Helvetica, Arial and Liberation Sans in
Schibsted Grotesk's metrics (size-adjust 102.58%, ascent 95.24%, descent 25.15%, no
line gap) so the `display=swap` handoff changes glyph shapes without moving anything.

**Docs media** — the getting-started `<video>` carries `1500x1065` and a matching
`aspect-ratio`; the mobile card-layout GIF moves to an `<img>` with `640x392`. Both
reserve their space before the file resolves.

**Demo placeholder** — the adapter placeholder reserves 472px, matching the 463–580px
a mounted table settles at across all nine kits, instead of collapsing the surface to
310px while a chunk loads.

**Redirect-stub crawler test** — fetches the stub's bytes through the request fixture
instead of navigating a page that races its own meta-refresh for the response body.
Identical assertions; the word count reads the fetched markup's `<main>`.

## Evidence

`pnpm check` green — all 13 steps (`format:check`, `lint`, `lint:root`,
`check:readmes`, `check:docsurface`, `check:parts`, `typecheck`, `test:coverage`,
`test:scripts`, `build`, `publint`, `smoke:dist`, `budget`).

`pnpm test:e2e` — 1219 passed after the stub-test change; the `pdf-export.spec.ts`
race no longer exists.

Playwright, Chromium and WebKit:

- Nav link bounding boxes are pixel-identical across a full scroll of the deck —
  max Δx 0.00px, max Δwidth 0.00px.
- Kit switching moves the demo surface by at most 80px, and by 0–37px for seven of the
  nine kits, down from a 201px collapse and 272px rebound.
- The reporter buckets a synthetic ResizeObserver-loop event as
  `{exception_type: "ResizeObserverLoop", fatal: false}`, truncates a message-only
  error to exactly 100 characters with `fatal: false`, and reports a real `TypeError`
  as `{exception_type: "TypeError", fatal: true}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
