### PR TITLE
chore(release): use the action's renamed script inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,8 +81,8 @@ jobs:
           # exists. Publish is build → publint → changeset publish — not
           # verify:release. ONE command: the action execs its publish input
           # without a shell, so a `&&` here would be a literal argument.
-          publish: pnpm release:gated
-          version: pnpm version-packages
+          publish-script: pnpm release:gated
+          version-script: pnpm version-packages
         env:
           # A fine-grained PAT scoped to this repository alone, with Contents
           # and Pull requests write and nothing else. Repository settings deny


### PR DESCRIPTION
## What changed

`changesets/action` v2 renamed its inputs — `publish` is `publish-script`, `version` is `version-script` — and fails fast on the old names. release.yml now uses the new names; the commands themselves are unchanged.

## Evidence

The failing Release run's error names exactly these two inputs; no other workflow uses the action, and no step consumes its outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)