### PR TITLE
chore(release): pass the release PAT through the github-token input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,14 +83,15 @@ jobs:
           # without a shell, so a `&&` here would be a literal argument.
           publish-script: pnpm release:gated
           version-script: pnpm version-packages
-        env:
           # A fine-grained PAT scoped to this repository alone, with Contents
           # and Pull requests write and nothing else. Repository settings deny
           # the workflow token the ability to create pull requests, so this is
           # the identity that opens the "Version Packages" PR — and because it
           # is a real account, that PR runs the required checks.
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          github-token: ${{ secrets.RELEASE_TOKEN }}
+        env:
+          # npm auth for `changeset publish`: setup-node's registry-url writes
+          # the .npmrc that reads this variable.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           # The version-bump commit must not run the husky gate on this
           # 2-core runner: CI enforces the same gate on every PR (including


### PR DESCRIPTION
## What changed

`changesets/action` v2 authenticates only through its `github-token` input and refuses to run when a `GITHUB_TOKEN` environment variable disagrees with it — the release PAT now flows through that input. The action no longer writes npm credentials, so publish auth is the setup-node `registry-url` + `NODE_AUTH_TOKEN` pair; the unread `NPM_TOKEN` variable is removed.

## Evidence

Audited against the pinned action commit: full input spec and README, plus a search of the compiled bundle — the step now matches the v2 documented shape, no other input or env is consumed, and no workflow step reads the action's outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)