### PR TITLE
fix: static demo navigation links, real docs targets, complete page titles

### DIFF
--- a/apps/docs/sync-docs.mjs
+++ b/apps/docs/sync-docs.mjs
@@ -20,7 +20,16 @@ const repoRoot = join(here, "../..");
 const source = join(here, "../../docs");
 const target = join(here, "src/content/docs");
 
-const TITLES = {
+/**
+ * Each page's `<title>`, keyed by its markdown file.
+ *
+ * A page with no entry here falls back to its own filename, so `filter-tree.md`
+ * ships as "filter-tree | AdaptTable" — a title that describes nothing and wins
+ * no search. `scripts/check-doc-surface.mjs` imports this map and fails when a
+ * `docs/*.md` page is missing from it, the same way it holds the sidebar and
+ * `docs/` to each other.
+ */
+export const TITLES = {
   "getting-started.md": "Get started — a React table for your UI kit",
   "concepts.md": "AdaptTable concepts — headless core & source",
   "columns.md": "React table columns — ColumnDef & custom cells",
@@ -30,6 +39,7 @@ const TITLES = {
   "export-pdf.md": "React table PDF export and print layout",
   "sorting.md": "React table sorting — multi-column, URL-synced",
   "filtering.md": "React table filtering — chips & URL-synced",
+  "filter-tree.md": "React table advanced filters — nested AND/OR groups",
   "pagination.md": "React table pagination — paged, infinite, auto",
   "selection.md": "React table row selection & bulk actions",
   "row-expansion.md": "React table expandable rows — detail panels",
@@ -41,6 +51,10 @@ const TITLES = {
   "row-styling.md": "React table row styling and heights",
   "cell-navigation.md": "React table keyboard navigation — ARIA grid",
   "row-grouping.md": "React table row grouping with subtotals",
+  "pivot.md": "React pivot table — rows, columns and measures",
+  "formulas.md": "React table formulas — spreadsheet computed columns",
+  "server-queries.md": "React table server queries — parse and validate",
+  "tree-data.md": "React table tree data — hierarchical rows",
   "column-management.md": "React table column management — pin, resize",
   "saved-views.md": "React table saved views, shareable by URL",
   "virtualization.md": "React table virtualization — 50k rows, 24 nodes",
@@ -55,6 +69,7 @@ const TITLES = {
   "api.md": "AdaptTable API reference — every export",
   "faq.md": "FAQ — the free MUI X & ag-Grid alternative",
   "comparison.md": "React table comparison — AG Grid, TanStack, MUI",
+  "migrate-from-v1.md": "Migrate from AdaptTable v1 to v2 — every rename",
   "migrate-from-mantine-datatable.md":
     "Migrate from mantine-datatable — more built-in",
   "migrate-from-mui-x-datagrid.md":
@@ -225,64 +240,70 @@ function headBlock(entries) {
   return `head:\n${entries.join("\n")}\n`;
 }
 
-mkdirSync(target, { recursive: true });
-for (const file of readdirSync(source)) {
-  if (!file.endsWith(".md")) continue;
-  const raw = readFileSync(join(source, file), "utf8");
-  // Drop the H1 (Starlight renders the frontmatter title) and rewrite
-  // repo-relative links into their site equivalents: doc-to-doc .md links
-  // become page routes (anchors preserved), repo files point at GitHub.
-  const body = raw
-    .replace(/^# .*\n/, "")
-    .replace(
-      /\((?:\.\/)?([a-z0-9-]+)\.md(#[a-z0-9-]+)?\)/g,
-      "(/adapttable/$1/$2)"
-    )
-    .replace(
-      /\(\.\.\/([^)]+)\)/g,
-      "(https://github.com/orwa-mahmoud/adapttable/blob/main/$1)"
-    );
-  const title = TITLES[file] ?? file.replace(/\.md$/, "");
-  const description = DESCRIPTIONS[file];
-  const slug = file.replace(/\.md$/, "");
+function syncDocs() {
+  mkdirSync(target, { recursive: true });
+  for (const file of readdirSync(source)) {
+    if (!file.endsWith(".md")) continue;
+    const raw = readFileSync(join(source, file), "utf8");
+    // Drop the H1 (Starlight renders the frontmatter title) and rewrite
+    // repo-relative links into their site equivalents: doc-to-doc .md links
+    // become page routes (anchors preserved), repo files point at GitHub.
+    const body = raw
+      .replace(/^# .*\n/, "")
+      .replace(
+        /\((?:\.\/)?([a-z0-9-]+)\.md(#[a-z0-9-]+)?\)/g,
+        "(/adapttable/$1/$2)"
+      )
+      .replace(
+        /\(\.\.\/([^)]+)\)/g,
+        "(https://github.com/orwa-mahmoud/adapttable/blob/main/$1)"
+      );
+    const title = TITLES[file] ?? file.replace(/\.md$/, "");
+    const description = DESCRIPTIONS[file];
+    const slug = file.replace(/\.md$/, "");
 
-  // Structured data: a BreadcrumbList on every page, plus FAQPage on the FAQ
-  // so its Q&As are eligible for Google rich results.
-  const jsonLd = [breadcrumbList(title, slug)];
-  if (file === "faq.md") jsonLd.push(faqPage(parseFaq(raw)));
+    // Structured data: a BreadcrumbList on every page, plus FAQPage on the FAQ
+    // so its Q&As are eligible for Google rich results.
+    const jsonLd = [breadcrumbList(title, slug)];
+    if (file === "faq.md") jsonLd.push(faqPage(parseFaq(raw)));
 
-  // Per-page social-share card (generated under public/og/<slug>.png).
-  const ogImage = `${SITE}/og/${slug}.png`;
-  const head = [
-    ...jsonLd.map(ldScript),
-    metaEntry("property", "og:image", ogImage),
-    metaEntry("name", "twitter:image", ogImage),
-  ];
+    // Per-page social-share card (generated under public/og/<slug>.png).
+    const ogImage = `${SITE}/og/${slug}.png`;
+    const head = [
+      ...jsonLd.map(ldScript),
+      metaEntry("property", "og:image", ogImage),
+      metaEntry("name", "twitter:image", ogImage),
+    ];
 
-  const fm = [`title: ${JSON.stringify(title)}`];
-  if (description) fm.push(`description: ${JSON.stringify(description)}`);
-  const frontmatter = `---\n${fm.join("\n")}\n${headBlock(head)}---\n\n`;
-  writeFileSync(join(target, file), `${frontmatter}${body}`);
-}
-// LLM-search surface (llmstxt.org): /llms.txt is the index, /llms-full.txt
-// the whole documentation in one file. Tools like Perplexity/ChatGPT
-// search fetch these from the site root, so they ship with every deploy.
-// llms-full.txt is regenerated from docs/ right here so it can never go
-// stale; llms.txt is the hand-written root index, copied verbatim.
-const pub = join(here, "public");
-mkdirSync(pub, { recursive: true });
-buildLlmsFull(repoRoot);
-copyFileSync(join(repoRoot, "llms-full.txt"), join(pub, "llms-full.txt"));
-const llmsIndex = readFileSync(join(repoRoot, "llms.txt"), "utf8");
-const unlinked = readdirSync(source).filter(
-  (file) =>
-    file.endsWith(".md") &&
-    !llmsIndex.includes(`/adapttable/${file.replace(/\.md$/, "")}/`)
-);
-if (unlinked.length > 0) {
-  console.warn(
-    `sync-docs: llms.txt has no link for: ${unlinked.join(", ")} — add them to the root llms.txt Docs list`
+    const fm = [`title: ${JSON.stringify(title)}`];
+    if (description) fm.push(`description: ${JSON.stringify(description)}`);
+    const frontmatter = `---\n${fm.join("\n")}\n${headBlock(head)}---\n\n`;
+    writeFileSync(join(target, file), `${frontmatter}${body}`);
+  }
+  // LLM-search surface (llmstxt.org): /llms.txt is the index, /llms-full.txt
+  // the whole documentation in one file. Tools like Perplexity/ChatGPT
+  // search fetch these from the site root, so they ship with every deploy.
+  // llms-full.txt is regenerated from docs/ right here so it can never go
+  // stale; llms.txt is the hand-written root index, copied verbatim.
+  const pub = join(here, "public");
+  mkdirSync(pub, { recursive: true });
+  buildLlmsFull(repoRoot);
+  copyFileSync(join(repoRoot, "llms-full.txt"), join(pub, "llms-full.txt"));
+  const llmsIndex = readFileSync(join(repoRoot, "llms.txt"), "utf8");
+  const unlinked = readdirSync(source).filter(
+    (file) =>
+      file.endsWith(".md") &&
+      !llmsIndex.includes(`/adapttable/${file.replace(/\.md$/, "")}/`)
   );
+  if (unlinked.length > 0) {
+    console.warn(
+      `sync-docs: llms.txt has no link for: ${unlinked.join(", ")} — add them to the root llms.txt Docs list`
+    );
+  }
+  copyFileSync(join(repoRoot, "llms.txt"), join(pub, "llms.txt"));
+  console.log("docs synced into Starlight");
 }
-copyFileSync(join(repoRoot, "llms.txt"), join(pub, "llms.txt"));
-console.log("docs synced into Starlight");
+
+// The docs build runs this as a script; the doc-surface gate imports it for
+// TITLES alone, and importing must not write into the content collection.
+if (process.argv[1] === fileURLToPath(import.meta.url)) syncDocs();

--- a/apps/showcase/antd/accessibility/index.html
+++ b/apps/showcase/antd/accessibility/index.html
@@ -163,6 +163,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/accessibility/">Accessible Mantine data table</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/accessibility/">Accessible MUI data table</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/accessibility/">Accessible Chakra data table</a> — Soft teal, generous radius</li>
+          <li><a href="../../radix/accessibility/">Accessible Radix data table</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/accessibility/">Accessible Base UI data table</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/accessibility/">Accessible shadcn data table</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/accessibility/">Accessible Tailwind data table</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Ant Design features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Ant Design</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Ant Design</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Ant Design</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Ant Design</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Ant Design</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Ant Design</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Ant Design</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Ant Design</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Ant Design</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Ant Design</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Ant Design</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Ant Design</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Ant Design</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Ant Design</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Ant Design</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Ant Design data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Ant Design</a> — Rows change while you read them. Sort and selection hold.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/accessibility/">accessibility</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or

--- a/apps/showcase/antd/column-groups/index.html
+++ b/apps/showcase/antd/column-groups/index.html
@@ -189,6 +189,36 @@ export function People({ rows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/column-groups/">Column groups in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/column-groups/">Column groups in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/column-groups/">Column groups in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../radix/column-groups/">Column groups in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/column-groups/">Column groups in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/column-groups/">Column groups in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/column-groups/">Column groups in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Ant Design features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Ant Design</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Ant Design</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../selection/">Row selection in Ant Design</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Ant Design</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Ant Design</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Ant Design</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Ant Design</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Ant Design</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Ant Design</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Ant Design</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Ant Design</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Ant Design</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Ant Design</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Ant Design</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Ant Design data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Ant Design</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Ant Design data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/column-groups/">column-groups</a>, <a href="https://orwa-mahmoud.github.io/adapttable/columns/">columns</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or

--- a/apps/showcase/antd/columns/index.html
+++ b/apps/showcase/antd/columns/index.html
@@ -165,6 +165,36 @@ export function People({ rows, columns, layout, onLayout }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/columns/">Column management in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/columns/">Column management in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/columns/">Column management in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../radix/columns/">Column management in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/columns/">Column management in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/columns/">Column management in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/columns/">Column management in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Ant Design features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Ant Design</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../column-groups/">Column groups in Ant Design</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Ant Design</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Ant Design</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Ant Design</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Ant Design</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Ant Design</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Ant Design</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Ant Design</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Ant Design</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Ant Design</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Ant Design</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Ant Design</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Ant Design</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Ant Design data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Ant Design</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Ant Design data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/column-management/">column-management</a>, <a href="https://orwa-mahmoud.github.io/adapttable/columns/">columns</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or

--- a/apps/showcase/antd/editing/index.html
+++ b/apps/showcase/antd/editing/index.html
@@ -176,6 +176,36 @@ export function People({ rows, onSave }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/editing/">Inline cell editing in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/editing/">Inline cell editing in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/editing/">Inline cell editing in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../radix/editing/">Inline cell editing in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/editing/">Inline cell editing in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/editing/">Inline cell editing in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/editing/">Inline cell editing in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Ant Design features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Ant Design</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Ant Design</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Ant Design</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Ant Design</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Ant Design</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../grouping/">Row grouping in Ant Design</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Ant Design</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Ant Design</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Ant Design</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Ant Design</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Ant Design</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Ant Design</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Ant Design</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Ant Design</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Ant Design data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Ant Design</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Ant Design data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or

--- a/apps/showcase/antd/editing/index.html
+++ b/apps/showcase/antd/editing/index.html
@@ -177,7 +177,7 @@ export function People({ rows, onSave }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/editing/">editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/antd/export/index.html
+++ b/apps/showcase/antd/export/index.html
@@ -169,7 +169,7 @@ export function People({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-csv/">export-csv</a>, <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/antd/export/index.html
+++ b/apps/showcase/antd/export/index.html
@@ -168,6 +168,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/export/">Export and print in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/export/">Export and print in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/export/">Export and print in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../radix/export/">Export and print in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/export/">Export and print in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/export/">Export and print in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/export/">Export and print in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Ant Design features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Ant Design</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Ant Design</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Ant Design</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Ant Design</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Ant Design</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Ant Design</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Ant Design</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Ant Design</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../scale/">Large datasets in Ant Design</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Ant Design</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Ant Design</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Ant Design</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Ant Design</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Ant Design</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Ant Design data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Ant Design</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Ant Design data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or

--- a/apps/showcase/antd/filtering/index.html
+++ b/apps/showcase/antd/filtering/index.html
@@ -173,6 +173,36 @@ export function People({ rows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/filtering/">Filtering in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/filtering/">Filtering in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/filtering/">Filtering in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../radix/filtering/">Filtering in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/filtering/">Filtering in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/filtering/">Filtering in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/filtering/">Filtering in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Ant Design features</h2>
+        <ul>
+          <li><a href="../columns/">Column management in Ant Design</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Ant Design</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Ant Design</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Ant Design</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Ant Design</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Ant Design</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Ant Design</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Ant Design</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Ant Design</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Ant Design</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Ant Design</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Ant Design</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Ant Design</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Ant Design</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Ant Design data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Ant Design</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Ant Design data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/filtering/">filtering</a>, <a href="https://orwa-mahmoud.github.io/adapttable/filter-tree/">filter-tree</a>, <a href="https://orwa-mahmoud.github.io/adapttable/url-state/">url-state</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or

--- a/apps/showcase/antd/formulas/index.html
+++ b/apps/showcase/antd/formulas/index.html
@@ -175,6 +175,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/formulas/">Spreadsheet formulas in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/formulas/">Spreadsheet formulas in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/formulas/">Spreadsheet formulas in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../radix/formulas/">Spreadsheet formulas in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/formulas/">Spreadsheet formulas in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/formulas/">Spreadsheet formulas in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/formulas/">Spreadsheet formulas in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Ant Design features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Ant Design</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Ant Design</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Ant Design</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Ant Design</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Ant Design</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Ant Design</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Ant Design</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Ant Design</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Ant Design</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Ant Design</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Ant Design</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Ant Design</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Ant Design</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Ant Design</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../rtl/">Right-to-left Ant Design data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Ant Design</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Ant Design data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/formulas/">formulas</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or

--- a/apps/showcase/antd/grouping/index.html
+++ b/apps/showcase/antd/grouping/index.html
@@ -170,7 +170,7 @@ export function People({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/grouping/">grouping</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-grouping/">row-grouping</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/antd/grouping/index.html
+++ b/apps/showcase/antd/grouping/index.html
@@ -169,6 +169,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/grouping/">Row grouping in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/grouping/">Row grouping in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/grouping/">Row grouping in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../radix/grouping/">Row grouping in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/grouping/">Row grouping in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/grouping/">Row grouping in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/grouping/">Row grouping in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Ant Design features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Ant Design</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Ant Design</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Ant Design</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Ant Design</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Ant Design</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Ant Design</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../nested-tables/">Nested tables in Ant Design</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Ant Design</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Ant Design</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Ant Design</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Ant Design</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Ant Design</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Ant Design</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Ant Design</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Ant Design data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Ant Design</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Ant Design data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-grouping/">row-grouping</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or

--- a/apps/showcase/antd/index.html
+++ b/apps/showcase/antd/index.html
@@ -169,6 +169,17 @@
           <li><a href="./realtime/">Live updates in Ant Design</a> — Rows change while you read them. Sort and selection hold.</li>
           <li><a href="./accessibility/">Accessible Ant Design data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
         </ul>
+        <h2>The same table, in seven other kits</h2>
+        <p>Switching kit changes the components, never the model — the props on this page are the props there.</p>
+        <ul>
+          <li><a href="../mantine/">AdaptTable for Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../mui/">AdaptTable for MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../chakra/">AdaptTable for Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../radix/">AdaptTable for Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../base-ui/">AdaptTable for Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../shadcn/">AdaptTable for shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../tailwind/">AdaptTable for Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/getting-started/">getting started</a>. Or
           open <a href="/adapttable/demo/">the live demo</a> and switch kits on

--- a/apps/showcase/antd/mobile-cards/index.html
+++ b/apps/showcase/antd/mobile-cards/index.html
@@ -166,6 +166,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/mobile-cards/">Mobile cards in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/mobile-cards/">Mobile cards in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/mobile-cards/">Mobile cards in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../radix/mobile-cards/">Mobile cards in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/mobile-cards/">Mobile cards in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/mobile-cards/">Mobile cards in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/mobile-cards/">Mobile cards in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Ant Design features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Ant Design</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Ant Design</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Ant Design</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Ant Design</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Ant Design</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Ant Design</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Ant Design</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Ant Design</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Ant Design</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Ant Design</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Ant Design</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../pivot/">Pivot tables in Ant Design</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Ant Design</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Ant Design</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Ant Design data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Ant Design</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Ant Design data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/mobile/">mobile</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or

--- a/apps/showcase/antd/nested-tables/index.html
+++ b/apps/showcase/antd/nested-tables/index.html
@@ -172,6 +172,36 @@ export function People({ rows, columns, orderColumns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/nested-tables/">Nested tables in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/nested-tables/">Nested tables in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/nested-tables/">Nested tables in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../radix/nested-tables/">Nested tables in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/nested-tables/">Nested tables in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/nested-tables/">Nested tables in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/nested-tables/">Nested tables in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Ant Design features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Ant Design</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Ant Design</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Ant Design</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Ant Design</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Ant Design</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Ant Design</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Ant Design</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../export/">Export and print in Ant Design</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Ant Design</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Ant Design</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Ant Design</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Ant Design</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Ant Design</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Ant Design</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Ant Design data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Ant Design</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Ant Design data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/tree-data/">tree-data</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-expansion/">row-expansion</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or

--- a/apps/showcase/antd/pivot/index.html
+++ b/apps/showcase/antd/pivot/index.html
@@ -173,6 +173,36 @@ export function Spend({ rows, fields }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/pivot/">Pivot tables in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/pivot/">Pivot tables in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/pivot/">Pivot tables in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../radix/pivot/">Pivot tables in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/pivot/">Pivot tables in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/pivot/">Pivot tables in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/pivot/">Pivot tables in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Ant Design features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Ant Design</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Ant Design</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Ant Design</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Ant Design</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Ant Design</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Ant Design</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Ant Design</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Ant Design</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Ant Design</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Ant Design</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Ant Design</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Ant Design</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../saved-views/">Saved views in Ant Design</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Ant Design</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Ant Design data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Ant Design</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Ant Design data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/pivot/">pivot</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or

--- a/apps/showcase/antd/realtime/index.html
+++ b/apps/showcase/antd/realtime/index.html
@@ -170,6 +170,36 @@ export function People({ rows, columns, setRows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/realtime/">Live updates in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/realtime/">Live updates in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/realtime/">Live updates in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../radix/realtime/">Live updates in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/realtime/">Live updates in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/realtime/">Live updates in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/realtime/">Live updates in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Ant Design features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Ant Design</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Ant Design</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Ant Design</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Ant Design</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Ant Design</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Ant Design</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Ant Design</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Ant Design</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Ant Design</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Ant Design</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Ant Design</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Ant Design</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Ant Design</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Ant Design</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Ant Design</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Ant Design data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../accessibility/">Accessible Ant Design data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/realtime/">realtime</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or

--- a/apps/showcase/antd/rows/index.html
+++ b/apps/showcase/antd/rows/index.html
@@ -165,6 +165,36 @@ export function People({ rows, columns, onReorder, setPinned, spanTeam }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/rows/">Rows in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/rows/">Rows in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/rows/">Rows in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../radix/rows/">Rows in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/rows/">Rows in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/rows/">Rows in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/rows/">Rows in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Ant Design features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Ant Design</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Ant Design</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Ant Design</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Ant Design</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../editing/">Inline cell editing in Ant Design</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Ant Design</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Ant Design</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Ant Design</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Ant Design</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Ant Design</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Ant Design</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Ant Design</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Ant Design</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Ant Design</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Ant Design data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Ant Design</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Ant Design data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-pinning/">row-pinning</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-reordering/">row-reordering</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-spanning/">row-spanning</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or

--- a/apps/showcase/antd/rtl/index.html
+++ b/apps/showcase/antd/rtl/index.html
@@ -163,6 +163,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/rtl/">Right-to-left Mantine data table</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/rtl/">Right-to-left MUI data table</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/rtl/">Right-to-left Chakra data table</a> — Soft teal, generous radius</li>
+          <li><a href="../../radix/rtl/">Right-to-left Radix data table</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/rtl/">Right-to-left Base UI data table</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/rtl/">Right-to-left shadcn data table</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/rtl/">Right-to-left Tailwind data table</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Ant Design features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Ant Design</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Ant Design</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Ant Design</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Ant Design</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Ant Design</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Ant Design</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Ant Design</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Ant Design</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Ant Design</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Ant Design</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Ant Design</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Ant Design</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Ant Design</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Ant Design</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Ant Design</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../realtime/">Live updates in Ant Design</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Ant Design data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/i18n-rtl/">i18n-rtl</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or

--- a/apps/showcase/antd/saved-views/index.html
+++ b/apps/showcase/antd/saved-views/index.html
@@ -181,6 +181,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/saved-views/">Saved views in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/saved-views/">Saved views in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/saved-views/">Saved views in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../radix/saved-views/">Saved views in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/saved-views/">Saved views in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/saved-views/">Saved views in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/saved-views/">Saved views in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Ant Design features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Ant Design</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Ant Design</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Ant Design</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Ant Design</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Ant Design</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Ant Design</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Ant Design</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Ant Design</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Ant Design</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Ant Design</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Ant Design</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Ant Design</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Ant Design</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Ant Design</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Ant Design data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Ant Design</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Ant Design data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/saved-views/">saved-views</a>, <a href="https://orwa-mahmoud.github.io/adapttable/url-state/">url-state</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or

--- a/apps/showcase/antd/scale/index.html
+++ b/apps/showcase/antd/scale/index.html
@@ -166,7 +166,7 @@ export function Ledger({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/performance/">performance</a>, <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/antd/scale/index.html
+++ b/apps/showcase/antd/scale/index.html
@@ -165,6 +165,36 @@ export function Ledger({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/scale/">Large datasets in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/scale/">Large datasets in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/scale/">Large datasets in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../radix/scale/">Large datasets in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/scale/">Large datasets in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/scale/">Large datasets in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/scale/">Large datasets in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Ant Design features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Ant Design</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Ant Design</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Ant Design</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Ant Design</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Ant Design</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Ant Design</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Ant Design</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Ant Design</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Ant Design</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../tree/">Tree data in Ant Design</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Ant Design</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Ant Design</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Ant Design</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Ant Design</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Ant Design data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Ant Design</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Ant Design data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or

--- a/apps/showcase/antd/selection/index.html
+++ b/apps/showcase/antd/selection/index.html
@@ -169,6 +169,36 @@ export function People({ rows, columns, onArchive }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/selection/">Row selection in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/selection/">Row selection in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/selection/">Row selection in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../radix/selection/">Row selection in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/selection/">Row selection in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/selection/">Row selection in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/selection/">Row selection in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Ant Design features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Ant Design</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Ant Design</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Ant Design</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../rows/">Rows in Ant Design</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Ant Design</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Ant Design</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Ant Design</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Ant Design</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Ant Design</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Ant Design</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Ant Design</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Ant Design</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Ant Design</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Ant Design</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Ant Design data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Ant Design</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Ant Design data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or

--- a/apps/showcase/antd/selection/index.html
+++ b/apps/showcase/antd/selection/index.html
@@ -170,7 +170,7 @@ export function People({ rows, columns, onArchive }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>, <a href="https://orwa-mahmoud.github.io/adapttable/bulk-actions/">bulk-actions</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/antd/tree/index.html
+++ b/apps/showcase/antd/tree/index.html
@@ -164,6 +164,36 @@ export function Org({ people, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/antd @adapttable/core antd</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/tree/">Tree data in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/tree/">Tree data in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/tree/">Tree data in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../radix/tree/">Tree data in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/tree/">Tree data in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/tree/">Tree data in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/tree/">Tree data in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Ant Design features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Ant Design</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Ant Design</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Ant Design</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Ant Design</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Ant Design</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Ant Design</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Ant Design</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Ant Design</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Ant Design</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Ant Design</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Ant Design</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Ant Design</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Ant Design</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Ant Design</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Ant Design data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Ant Design</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Ant Design data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/tree-data/">tree-data</a>. More of this kit:
           <a href="../">AdaptTable for Ant Design</a>, or

--- a/apps/showcase/base-ui/accessibility/index.html
+++ b/apps/showcase/base-ui/accessibility/index.html
@@ -163,6 +163,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/accessibility/">Accessible Mantine data table</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/accessibility/">Accessible MUI data table</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/accessibility/">Accessible Chakra data table</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/accessibility/">Accessible Ant Design data table</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/accessibility/">Accessible Radix data table</a> — Radix Themes, iris accent</li>
+          <li><a href="../../shadcn/accessibility/">Accessible shadcn data table</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/accessibility/">Accessible Tailwind data table</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Base UI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Base UI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Base UI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Base UI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Base UI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Base UI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Base UI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Base UI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Base UI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Base UI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Base UI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Base UI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Base UI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Base UI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Base UI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Base UI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Base UI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Base UI</a> — Rows change while you read them. Sort and selection hold.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/accessibility/">accessibility</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or

--- a/apps/showcase/base-ui/column-groups/index.html
+++ b/apps/showcase/base-ui/column-groups/index.html
@@ -189,6 +189,36 @@ export function People({ rows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/column-groups/">Column groups in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/column-groups/">Column groups in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/column-groups/">Column groups in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/column-groups/">Column groups in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/column-groups/">Column groups in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../shadcn/column-groups/">Column groups in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/column-groups/">Column groups in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Base UI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Base UI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Base UI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../selection/">Row selection in Base UI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Base UI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Base UI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Base UI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Base UI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Base UI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Base UI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Base UI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Base UI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Base UI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Base UI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Base UI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Base UI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Base UI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Base UI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/column-groups/">column-groups</a>, <a href="https://orwa-mahmoud.github.io/adapttable/columns/">columns</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or

--- a/apps/showcase/base-ui/columns/index.html
+++ b/apps/showcase/base-ui/columns/index.html
@@ -165,6 +165,36 @@ export function People({ rows, columns, layout, onLayout }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/columns/">Column management in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/columns/">Column management in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/columns/">Column management in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/columns/">Column management in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/columns/">Column management in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../shadcn/columns/">Column management in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/columns/">Column management in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Base UI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Base UI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../column-groups/">Column groups in Base UI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Base UI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Base UI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Base UI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Base UI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Base UI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Base UI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Base UI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Base UI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Base UI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Base UI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Base UI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Base UI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Base UI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Base UI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Base UI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/column-management/">column-management</a>, <a href="https://orwa-mahmoud.github.io/adapttable/columns/">columns</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or

--- a/apps/showcase/base-ui/editing/index.html
+++ b/apps/showcase/base-ui/editing/index.html
@@ -177,7 +177,7 @@ export function People({ rows, onSave }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/editing/">editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/base-ui/editing/index.html
+++ b/apps/showcase/base-ui/editing/index.html
@@ -176,6 +176,36 @@ export function People({ rows, onSave }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/editing/">Inline cell editing in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/editing/">Inline cell editing in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/editing/">Inline cell editing in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/editing/">Inline cell editing in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/editing/">Inline cell editing in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../shadcn/editing/">Inline cell editing in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/editing/">Inline cell editing in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Base UI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Base UI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Base UI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Base UI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Base UI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Base UI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../grouping/">Row grouping in Base UI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Base UI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Base UI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Base UI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Base UI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Base UI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Base UI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Base UI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Base UI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Base UI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Base UI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Base UI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or

--- a/apps/showcase/base-ui/export/index.html
+++ b/apps/showcase/base-ui/export/index.html
@@ -169,7 +169,7 @@ export function People({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-csv/">export-csv</a>, <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/base-ui/export/index.html
+++ b/apps/showcase/base-ui/export/index.html
@@ -168,6 +168,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/export/">Export and print in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/export/">Export and print in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/export/">Export and print in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/export/">Export and print in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/export/">Export and print in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../shadcn/export/">Export and print in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/export/">Export and print in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Base UI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Base UI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Base UI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Base UI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Base UI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Base UI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Base UI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Base UI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Base UI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../scale/">Large datasets in Base UI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Base UI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Base UI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Base UI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Base UI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Base UI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Base UI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Base UI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Base UI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or

--- a/apps/showcase/base-ui/filtering/index.html
+++ b/apps/showcase/base-ui/filtering/index.html
@@ -173,6 +173,36 @@ export function People({ rows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/filtering/">Filtering in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/filtering/">Filtering in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/filtering/">Filtering in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/filtering/">Filtering in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/filtering/">Filtering in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../shadcn/filtering/">Filtering in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/filtering/">Filtering in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Base UI features</h2>
+        <ul>
+          <li><a href="../columns/">Column management in Base UI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Base UI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Base UI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Base UI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Base UI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Base UI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Base UI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Base UI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Base UI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Base UI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Base UI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Base UI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Base UI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Base UI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Base UI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Base UI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Base UI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/filtering/">filtering</a>, <a href="https://orwa-mahmoud.github.io/adapttable/filter-tree/">filter-tree</a>, <a href="https://orwa-mahmoud.github.io/adapttable/url-state/">url-state</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or

--- a/apps/showcase/base-ui/formulas/index.html
+++ b/apps/showcase/base-ui/formulas/index.html
@@ -175,6 +175,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/formulas/">Spreadsheet formulas in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/formulas/">Spreadsheet formulas in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/formulas/">Spreadsheet formulas in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/formulas/">Spreadsheet formulas in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/formulas/">Spreadsheet formulas in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../shadcn/formulas/">Spreadsheet formulas in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/formulas/">Spreadsheet formulas in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Base UI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Base UI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Base UI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Base UI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Base UI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Base UI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Base UI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Base UI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Base UI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Base UI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Base UI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Base UI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Base UI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Base UI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Base UI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../rtl/">Right-to-left Base UI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Base UI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Base UI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/formulas/">formulas</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or

--- a/apps/showcase/base-ui/grouping/index.html
+++ b/apps/showcase/base-ui/grouping/index.html
@@ -170,7 +170,7 @@ export function People({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/grouping/">grouping</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-grouping/">row-grouping</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/base-ui/grouping/index.html
+++ b/apps/showcase/base-ui/grouping/index.html
@@ -169,6 +169,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/grouping/">Row grouping in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/grouping/">Row grouping in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/grouping/">Row grouping in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/grouping/">Row grouping in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/grouping/">Row grouping in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../shadcn/grouping/">Row grouping in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/grouping/">Row grouping in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Base UI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Base UI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Base UI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Base UI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Base UI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Base UI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Base UI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../nested-tables/">Nested tables in Base UI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Base UI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Base UI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Base UI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Base UI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Base UI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Base UI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Base UI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Base UI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Base UI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Base UI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-grouping/">row-grouping</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or

--- a/apps/showcase/base-ui/index.html
+++ b/apps/showcase/base-ui/index.html
@@ -169,6 +169,17 @@
           <li><a href="./realtime/">Live updates in Base UI</a> — Rows change while you read them. Sort and selection hold.</li>
           <li><a href="./accessibility/">Accessible Base UI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
         </ul>
+        <h2>The same table, in seven other kits</h2>
+        <p>Switching kit changes the components, never the model — the props on this page are the props there.</p>
+        <ul>
+          <li><a href="../mantine/">AdaptTable for Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../mui/">AdaptTable for MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../chakra/">AdaptTable for Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../antd/">AdaptTable for Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../radix/">AdaptTable for Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../shadcn/">AdaptTable for shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../tailwind/">AdaptTable for Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/getting-started/">getting started</a>. Or
           open <a href="/adapttable/demo/">the live demo</a> and switch kits on

--- a/apps/showcase/base-ui/mobile-cards/index.html
+++ b/apps/showcase/base-ui/mobile-cards/index.html
@@ -166,6 +166,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/mobile-cards/">Mobile cards in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/mobile-cards/">Mobile cards in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/mobile-cards/">Mobile cards in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/mobile-cards/">Mobile cards in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/mobile-cards/">Mobile cards in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../shadcn/mobile-cards/">Mobile cards in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/mobile-cards/">Mobile cards in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Base UI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Base UI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Base UI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Base UI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Base UI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Base UI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Base UI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Base UI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Base UI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Base UI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Base UI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Base UI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../pivot/">Pivot tables in Base UI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Base UI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Base UI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Base UI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Base UI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Base UI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/mobile/">mobile</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or

--- a/apps/showcase/base-ui/nested-tables/index.html
+++ b/apps/showcase/base-ui/nested-tables/index.html
@@ -172,6 +172,36 @@ export function People({ rows, columns, orderColumns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/nested-tables/">Nested tables in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/nested-tables/">Nested tables in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/nested-tables/">Nested tables in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/nested-tables/">Nested tables in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/nested-tables/">Nested tables in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../shadcn/nested-tables/">Nested tables in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/nested-tables/">Nested tables in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Base UI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Base UI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Base UI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Base UI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Base UI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Base UI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Base UI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Base UI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../export/">Export and print in Base UI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Base UI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Base UI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Base UI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Base UI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Base UI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Base UI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Base UI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Base UI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Base UI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/tree-data/">tree-data</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-expansion/">row-expansion</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or

--- a/apps/showcase/base-ui/pivot/index.html
+++ b/apps/showcase/base-ui/pivot/index.html
@@ -173,6 +173,36 @@ export function Spend({ rows, fields }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/pivot/">Pivot tables in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/pivot/">Pivot tables in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/pivot/">Pivot tables in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/pivot/">Pivot tables in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/pivot/">Pivot tables in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../shadcn/pivot/">Pivot tables in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/pivot/">Pivot tables in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Base UI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Base UI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Base UI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Base UI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Base UI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Base UI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Base UI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Base UI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Base UI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Base UI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Base UI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Base UI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Base UI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../saved-views/">Saved views in Base UI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Base UI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Base UI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Base UI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Base UI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/pivot/">pivot</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or

--- a/apps/showcase/base-ui/realtime/index.html
+++ b/apps/showcase/base-ui/realtime/index.html
@@ -170,6 +170,36 @@ export function People({ rows, columns, setRows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/realtime/">Live updates in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/realtime/">Live updates in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/realtime/">Live updates in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/realtime/">Live updates in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/realtime/">Live updates in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../shadcn/realtime/">Live updates in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/realtime/">Live updates in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Base UI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Base UI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Base UI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Base UI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Base UI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Base UI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Base UI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Base UI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Base UI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Base UI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Base UI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Base UI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Base UI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Base UI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Base UI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Base UI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Base UI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../accessibility/">Accessible Base UI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/realtime/">realtime</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or

--- a/apps/showcase/base-ui/rows/index.html
+++ b/apps/showcase/base-ui/rows/index.html
@@ -165,6 +165,36 @@ export function People({ rows, columns, onReorder, setPinned, spanTeam }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/rows/">Rows in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/rows/">Rows in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/rows/">Rows in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/rows/">Rows in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/rows/">Rows in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../shadcn/rows/">Rows in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/rows/">Rows in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Base UI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Base UI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Base UI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Base UI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Base UI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../editing/">Inline cell editing in Base UI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Base UI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Base UI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Base UI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Base UI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Base UI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Base UI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Base UI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Base UI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Base UI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Base UI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Base UI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Base UI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-pinning/">row-pinning</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-reordering/">row-reordering</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-spanning/">row-spanning</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or

--- a/apps/showcase/base-ui/rtl/index.html
+++ b/apps/showcase/base-ui/rtl/index.html
@@ -163,6 +163,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/rtl/">Right-to-left Mantine data table</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/rtl/">Right-to-left MUI data table</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/rtl/">Right-to-left Chakra data table</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/rtl/">Right-to-left Ant Design data table</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/rtl/">Right-to-left Radix data table</a> — Radix Themes, iris accent</li>
+          <li><a href="../../shadcn/rtl/">Right-to-left shadcn data table</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/rtl/">Right-to-left Tailwind data table</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Base UI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Base UI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Base UI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Base UI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Base UI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Base UI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Base UI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Base UI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Base UI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Base UI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Base UI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Base UI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Base UI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Base UI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Base UI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Base UI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../realtime/">Live updates in Base UI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Base UI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/i18n-rtl/">i18n-rtl</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or

--- a/apps/showcase/base-ui/saved-views/index.html
+++ b/apps/showcase/base-ui/saved-views/index.html
@@ -181,6 +181,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/saved-views/">Saved views in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/saved-views/">Saved views in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/saved-views/">Saved views in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/saved-views/">Saved views in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/saved-views/">Saved views in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../shadcn/saved-views/">Saved views in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/saved-views/">Saved views in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Base UI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Base UI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Base UI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Base UI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Base UI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Base UI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Base UI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Base UI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Base UI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Base UI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Base UI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Base UI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Base UI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Base UI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Base UI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Base UI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Base UI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Base UI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/saved-views/">saved-views</a>, <a href="https://orwa-mahmoud.github.io/adapttable/url-state/">url-state</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or

--- a/apps/showcase/base-ui/scale/index.html
+++ b/apps/showcase/base-ui/scale/index.html
@@ -165,6 +165,36 @@ export function Ledger({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/scale/">Large datasets in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/scale/">Large datasets in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/scale/">Large datasets in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/scale/">Large datasets in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/scale/">Large datasets in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../shadcn/scale/">Large datasets in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/scale/">Large datasets in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Base UI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Base UI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Base UI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Base UI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Base UI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Base UI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Base UI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Base UI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Base UI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Base UI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../tree/">Tree data in Base UI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Base UI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Base UI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Base UI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Base UI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Base UI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Base UI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Base UI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or

--- a/apps/showcase/base-ui/scale/index.html
+++ b/apps/showcase/base-ui/scale/index.html
@@ -166,7 +166,7 @@ export function Ledger({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/performance/">performance</a>, <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/base-ui/selection/index.html
+++ b/apps/showcase/base-ui/selection/index.html
@@ -170,7 +170,7 @@ export function People({ rows, columns, onArchive }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>, <a href="https://orwa-mahmoud.github.io/adapttable/bulk-actions/">bulk-actions</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/base-ui/selection/index.html
+++ b/apps/showcase/base-ui/selection/index.html
@@ -169,6 +169,36 @@ export function People({ rows, columns, onArchive }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/selection/">Row selection in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/selection/">Row selection in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/selection/">Row selection in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/selection/">Row selection in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/selection/">Row selection in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../shadcn/selection/">Row selection in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/selection/">Row selection in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Base UI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Base UI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Base UI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Base UI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../rows/">Rows in Base UI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Base UI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Base UI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Base UI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Base UI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Base UI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Base UI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Base UI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Base UI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Base UI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Base UI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Base UI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Base UI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Base UI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or

--- a/apps/showcase/base-ui/tree/index.html
+++ b/apps/showcase/base-ui/tree/index.html
@@ -164,6 +164,36 @@ export function Org({ people, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/base-ui @adapttable/core @base-ui/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/tree/">Tree data in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/tree/">Tree data in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/tree/">Tree data in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/tree/">Tree data in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/tree/">Tree data in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../shadcn/tree/">Tree data in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/tree/">Tree data in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Base UI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Base UI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Base UI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Base UI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Base UI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Base UI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Base UI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Base UI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Base UI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Base UI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Base UI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Base UI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Base UI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Base UI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Base UI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Base UI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Base UI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Base UI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/tree-data/">tree-data</a>. More of this kit:
           <a href="../">AdaptTable for Base UI</a>, or

--- a/apps/showcase/chakra/accessibility/index.html
+++ b/apps/showcase/chakra/accessibility/index.html
@@ -163,6 +163,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/accessibility/">Accessible Mantine data table</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/accessibility/">Accessible MUI data table</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../antd/accessibility/">Accessible Ant Design data table</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/accessibility/">Accessible Radix data table</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/accessibility/">Accessible Base UI data table</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/accessibility/">Accessible shadcn data table</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/accessibility/">Accessible Tailwind data table</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Chakra features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Chakra</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Chakra</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Chakra</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Chakra</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Chakra</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Chakra</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Chakra</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Chakra</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Chakra</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Chakra</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Chakra</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Chakra</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Chakra</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Chakra</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Chakra</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Chakra data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Chakra</a> — Rows change while you read them. Sort and selection hold.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/accessibility/">accessibility</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or

--- a/apps/showcase/chakra/column-groups/index.html
+++ b/apps/showcase/chakra/column-groups/index.html
@@ -189,6 +189,36 @@ export function People({ rows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/column-groups/">Column groups in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/column-groups/">Column groups in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../antd/column-groups/">Column groups in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/column-groups/">Column groups in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/column-groups/">Column groups in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/column-groups/">Column groups in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/column-groups/">Column groups in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Chakra features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Chakra</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Chakra</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../selection/">Row selection in Chakra</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Chakra</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Chakra</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Chakra</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Chakra</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Chakra</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Chakra</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Chakra</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Chakra</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Chakra</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Chakra</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Chakra</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Chakra data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Chakra</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Chakra data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/column-groups/">column-groups</a>, <a href="https://orwa-mahmoud.github.io/adapttable/columns/">columns</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or

--- a/apps/showcase/chakra/columns/index.html
+++ b/apps/showcase/chakra/columns/index.html
@@ -165,6 +165,36 @@ export function People({ rows, columns, layout, onLayout }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/columns/">Column management in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/columns/">Column management in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../antd/columns/">Column management in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/columns/">Column management in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/columns/">Column management in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/columns/">Column management in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/columns/">Column management in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Chakra features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Chakra</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../column-groups/">Column groups in Chakra</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Chakra</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Chakra</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Chakra</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Chakra</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Chakra</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Chakra</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Chakra</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Chakra</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Chakra</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Chakra</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Chakra</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Chakra</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Chakra data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Chakra</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Chakra data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/column-management/">column-management</a>, <a href="https://orwa-mahmoud.github.io/adapttable/columns/">columns</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or

--- a/apps/showcase/chakra/editing/index.html
+++ b/apps/showcase/chakra/editing/index.html
@@ -176,6 +176,36 @@ export function People({ rows, onSave }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/editing/">Inline cell editing in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/editing/">Inline cell editing in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../antd/editing/">Inline cell editing in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/editing/">Inline cell editing in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/editing/">Inline cell editing in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/editing/">Inline cell editing in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/editing/">Inline cell editing in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Chakra features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Chakra</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Chakra</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Chakra</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Chakra</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Chakra</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../grouping/">Row grouping in Chakra</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Chakra</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Chakra</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Chakra</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Chakra</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Chakra</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Chakra</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Chakra</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Chakra</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Chakra data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Chakra</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Chakra data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or

--- a/apps/showcase/chakra/editing/index.html
+++ b/apps/showcase/chakra/editing/index.html
@@ -177,7 +177,7 @@ export function People({ rows, onSave }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/editing/">editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/chakra/export/index.html
+++ b/apps/showcase/chakra/export/index.html
@@ -169,7 +169,7 @@ export function People({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-csv/">export-csv</a>, <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/chakra/export/index.html
+++ b/apps/showcase/chakra/export/index.html
@@ -168,6 +168,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/export/">Export and print in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/export/">Export and print in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../antd/export/">Export and print in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/export/">Export and print in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/export/">Export and print in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/export/">Export and print in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/export/">Export and print in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Chakra features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Chakra</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Chakra</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Chakra</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Chakra</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Chakra</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Chakra</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Chakra</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Chakra</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../scale/">Large datasets in Chakra</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Chakra</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Chakra</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Chakra</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Chakra</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Chakra</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Chakra data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Chakra</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Chakra data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or

--- a/apps/showcase/chakra/filtering/index.html
+++ b/apps/showcase/chakra/filtering/index.html
@@ -173,6 +173,36 @@ export function People({ rows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/filtering/">Filtering in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/filtering/">Filtering in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../antd/filtering/">Filtering in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/filtering/">Filtering in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/filtering/">Filtering in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/filtering/">Filtering in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/filtering/">Filtering in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Chakra features</h2>
+        <ul>
+          <li><a href="../columns/">Column management in Chakra</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Chakra</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Chakra</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Chakra</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Chakra</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Chakra</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Chakra</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Chakra</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Chakra</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Chakra</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Chakra</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Chakra</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Chakra</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Chakra</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Chakra data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Chakra</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Chakra data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/filtering/">filtering</a>, <a href="https://orwa-mahmoud.github.io/adapttable/filter-tree/">filter-tree</a>, <a href="https://orwa-mahmoud.github.io/adapttable/url-state/">url-state</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or

--- a/apps/showcase/chakra/formulas/index.html
+++ b/apps/showcase/chakra/formulas/index.html
@@ -175,6 +175,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/formulas/">Spreadsheet formulas in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/formulas/">Spreadsheet formulas in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../antd/formulas/">Spreadsheet formulas in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/formulas/">Spreadsheet formulas in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/formulas/">Spreadsheet formulas in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/formulas/">Spreadsheet formulas in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/formulas/">Spreadsheet formulas in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Chakra features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Chakra</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Chakra</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Chakra</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Chakra</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Chakra</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Chakra</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Chakra</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Chakra</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Chakra</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Chakra</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Chakra</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Chakra</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Chakra</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Chakra</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../rtl/">Right-to-left Chakra data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Chakra</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Chakra data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/formulas/">formulas</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or

--- a/apps/showcase/chakra/grouping/index.html
+++ b/apps/showcase/chakra/grouping/index.html
@@ -169,6 +169,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/grouping/">Row grouping in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/grouping/">Row grouping in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../antd/grouping/">Row grouping in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/grouping/">Row grouping in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/grouping/">Row grouping in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/grouping/">Row grouping in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/grouping/">Row grouping in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Chakra features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Chakra</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Chakra</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Chakra</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Chakra</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Chakra</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Chakra</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../nested-tables/">Nested tables in Chakra</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Chakra</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Chakra</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Chakra</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Chakra</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Chakra</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Chakra</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Chakra</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Chakra data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Chakra</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Chakra data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-grouping/">row-grouping</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or

--- a/apps/showcase/chakra/grouping/index.html
+++ b/apps/showcase/chakra/grouping/index.html
@@ -170,7 +170,7 @@ export function People({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/grouping/">grouping</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-grouping/">row-grouping</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/chakra/index.html
+++ b/apps/showcase/chakra/index.html
@@ -169,6 +169,17 @@
           <li><a href="./realtime/">Live updates in Chakra</a> — Rows change while you read them. Sort and selection hold.</li>
           <li><a href="./accessibility/">Accessible Chakra data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
         </ul>
+        <h2>The same table, in seven other kits</h2>
+        <p>Switching kit changes the components, never the model — the props on this page are the props there.</p>
+        <ul>
+          <li><a href="../mantine/">AdaptTable for Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../mui/">AdaptTable for MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../antd/">AdaptTable for Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../radix/">AdaptTable for Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../base-ui/">AdaptTable for Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../shadcn/">AdaptTable for shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../tailwind/">AdaptTable for Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/getting-started/">getting started</a>. Or
           open <a href="/adapttable/demo/">the live demo</a> and switch kits on

--- a/apps/showcase/chakra/mobile-cards/index.html
+++ b/apps/showcase/chakra/mobile-cards/index.html
@@ -166,6 +166,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/mobile-cards/">Mobile cards in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/mobile-cards/">Mobile cards in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../antd/mobile-cards/">Mobile cards in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/mobile-cards/">Mobile cards in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/mobile-cards/">Mobile cards in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/mobile-cards/">Mobile cards in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/mobile-cards/">Mobile cards in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Chakra features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Chakra</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Chakra</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Chakra</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Chakra</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Chakra</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Chakra</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Chakra</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Chakra</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Chakra</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Chakra</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Chakra</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../pivot/">Pivot tables in Chakra</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Chakra</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Chakra</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Chakra data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Chakra</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Chakra data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/mobile/">mobile</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or

--- a/apps/showcase/chakra/nested-tables/index.html
+++ b/apps/showcase/chakra/nested-tables/index.html
@@ -172,6 +172,36 @@ export function People({ rows, columns, orderColumns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/nested-tables/">Nested tables in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/nested-tables/">Nested tables in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../antd/nested-tables/">Nested tables in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/nested-tables/">Nested tables in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/nested-tables/">Nested tables in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/nested-tables/">Nested tables in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/nested-tables/">Nested tables in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Chakra features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Chakra</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Chakra</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Chakra</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Chakra</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Chakra</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Chakra</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Chakra</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../export/">Export and print in Chakra</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Chakra</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Chakra</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Chakra</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Chakra</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Chakra</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Chakra</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Chakra data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Chakra</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Chakra data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/tree-data/">tree-data</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-expansion/">row-expansion</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or

--- a/apps/showcase/chakra/pivot/index.html
+++ b/apps/showcase/chakra/pivot/index.html
@@ -173,6 +173,36 @@ export function Spend({ rows, fields }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/pivot/">Pivot tables in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/pivot/">Pivot tables in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../antd/pivot/">Pivot tables in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/pivot/">Pivot tables in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/pivot/">Pivot tables in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/pivot/">Pivot tables in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/pivot/">Pivot tables in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Chakra features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Chakra</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Chakra</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Chakra</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Chakra</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Chakra</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Chakra</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Chakra</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Chakra</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Chakra</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Chakra</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Chakra</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Chakra</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../saved-views/">Saved views in Chakra</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Chakra</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Chakra data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Chakra</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Chakra data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/pivot/">pivot</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or

--- a/apps/showcase/chakra/realtime/index.html
+++ b/apps/showcase/chakra/realtime/index.html
@@ -170,6 +170,36 @@ export function People({ rows, columns, setRows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/realtime/">Live updates in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/realtime/">Live updates in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../antd/realtime/">Live updates in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/realtime/">Live updates in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/realtime/">Live updates in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/realtime/">Live updates in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/realtime/">Live updates in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Chakra features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Chakra</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Chakra</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Chakra</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Chakra</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Chakra</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Chakra</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Chakra</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Chakra</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Chakra</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Chakra</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Chakra</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Chakra</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Chakra</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Chakra</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Chakra</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Chakra data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../accessibility/">Accessible Chakra data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/realtime/">realtime</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or

--- a/apps/showcase/chakra/rows/index.html
+++ b/apps/showcase/chakra/rows/index.html
@@ -165,6 +165,36 @@ export function People({ rows, columns, onReorder, setPinned, spanTeam }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/rows/">Rows in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/rows/">Rows in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../antd/rows/">Rows in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/rows/">Rows in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/rows/">Rows in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/rows/">Rows in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/rows/">Rows in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Chakra features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Chakra</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Chakra</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Chakra</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Chakra</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../editing/">Inline cell editing in Chakra</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Chakra</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Chakra</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Chakra</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Chakra</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Chakra</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Chakra</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Chakra</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Chakra</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Chakra</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Chakra data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Chakra</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Chakra data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-pinning/">row-pinning</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-reordering/">row-reordering</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-spanning/">row-spanning</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or

--- a/apps/showcase/chakra/rtl/index.html
+++ b/apps/showcase/chakra/rtl/index.html
@@ -163,6 +163,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/rtl/">Right-to-left Mantine data table</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/rtl/">Right-to-left MUI data table</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../antd/rtl/">Right-to-left Ant Design data table</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/rtl/">Right-to-left Radix data table</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/rtl/">Right-to-left Base UI data table</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/rtl/">Right-to-left shadcn data table</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/rtl/">Right-to-left Tailwind data table</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Chakra features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Chakra</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Chakra</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Chakra</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Chakra</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Chakra</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Chakra</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Chakra</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Chakra</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Chakra</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Chakra</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Chakra</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Chakra</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Chakra</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Chakra</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Chakra</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../realtime/">Live updates in Chakra</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Chakra data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/i18n-rtl/">i18n-rtl</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or

--- a/apps/showcase/chakra/saved-views/index.html
+++ b/apps/showcase/chakra/saved-views/index.html
@@ -181,6 +181,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/saved-views/">Saved views in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/saved-views/">Saved views in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../antd/saved-views/">Saved views in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/saved-views/">Saved views in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/saved-views/">Saved views in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/saved-views/">Saved views in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/saved-views/">Saved views in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Chakra features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Chakra</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Chakra</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Chakra</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Chakra</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Chakra</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Chakra</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Chakra</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Chakra</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Chakra</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Chakra</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Chakra</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Chakra</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Chakra</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Chakra</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Chakra data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Chakra</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Chakra data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/saved-views/">saved-views</a>, <a href="https://orwa-mahmoud.github.io/adapttable/url-state/">url-state</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or

--- a/apps/showcase/chakra/scale/index.html
+++ b/apps/showcase/chakra/scale/index.html
@@ -166,7 +166,7 @@ export function Ledger({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/performance/">performance</a>, <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/chakra/scale/index.html
+++ b/apps/showcase/chakra/scale/index.html
@@ -165,6 +165,36 @@ export function Ledger({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/scale/">Large datasets in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/scale/">Large datasets in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../antd/scale/">Large datasets in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/scale/">Large datasets in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/scale/">Large datasets in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/scale/">Large datasets in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/scale/">Large datasets in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Chakra features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Chakra</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Chakra</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Chakra</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Chakra</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Chakra</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Chakra</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Chakra</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Chakra</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Chakra</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../tree/">Tree data in Chakra</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Chakra</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Chakra</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Chakra</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Chakra</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Chakra data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Chakra</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Chakra data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or

--- a/apps/showcase/chakra/selection/index.html
+++ b/apps/showcase/chakra/selection/index.html
@@ -169,6 +169,36 @@ export function People({ rows, columns, onArchive }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/selection/">Row selection in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/selection/">Row selection in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../antd/selection/">Row selection in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/selection/">Row selection in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/selection/">Row selection in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/selection/">Row selection in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/selection/">Row selection in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Chakra features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Chakra</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Chakra</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Chakra</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../rows/">Rows in Chakra</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Chakra</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Chakra</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Chakra</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Chakra</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Chakra</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Chakra</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Chakra</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Chakra</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Chakra</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Chakra</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Chakra data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Chakra</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Chakra data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or

--- a/apps/showcase/chakra/selection/index.html
+++ b/apps/showcase/chakra/selection/index.html
@@ -170,7 +170,7 @@ export function People({ rows, columns, onArchive }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>, <a href="https://orwa-mahmoud.github.io/adapttable/bulk-actions/">bulk-actions</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/chakra/tree/index.html
+++ b/apps/showcase/chakra/tree/index.html
@@ -164,6 +164,36 @@ export function Org({ people, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/chakra @adapttable/core @chakra-ui/react @emotion/react</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/tree/">Tree data in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/tree/">Tree data in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../antd/tree/">Tree data in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/tree/">Tree data in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/tree/">Tree data in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/tree/">Tree data in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/tree/">Tree data in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Chakra features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Chakra</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Chakra</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Chakra</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Chakra</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Chakra</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Chakra</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Chakra</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Chakra</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Chakra</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Chakra</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Chakra</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Chakra</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Chakra</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Chakra</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Chakra data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Chakra</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Chakra data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/tree-data/">tree-data</a>. More of this kit:
           <a href="../">AdaptTable for Chakra</a>, or

--- a/apps/showcase/mantine/accessibility/index.html
+++ b/apps/showcase/mantine/accessibility/index.html
@@ -163,6 +163,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mui/accessibility/">Accessible MUI data table</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/accessibility/">Accessible Chakra data table</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/accessibility/">Accessible Ant Design data table</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/accessibility/">Accessible Radix data table</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/accessibility/">Accessible Base UI data table</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/accessibility/">Accessible shadcn data table</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/accessibility/">Accessible Tailwind data table</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Mantine features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Mantine</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Mantine</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Mantine</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Mantine</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Mantine</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Mantine</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Mantine</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Mantine</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Mantine</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Mantine</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Mantine</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Mantine</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Mantine</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Mantine</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Mantine</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Mantine data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Mantine</a> — Rows change while you read them. Sort and selection hold.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/accessibility/">accessibility</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or

--- a/apps/showcase/mantine/column-groups/index.html
+++ b/apps/showcase/mantine/column-groups/index.html
@@ -189,6 +189,36 @@ export function People({ rows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mui/column-groups/">Column groups in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/column-groups/">Column groups in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/column-groups/">Column groups in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/column-groups/">Column groups in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/column-groups/">Column groups in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/column-groups/">Column groups in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/column-groups/">Column groups in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Mantine features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Mantine</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Mantine</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../selection/">Row selection in Mantine</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Mantine</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Mantine</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Mantine</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Mantine</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Mantine</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Mantine</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Mantine</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Mantine</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Mantine</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Mantine</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Mantine</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Mantine data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Mantine</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Mantine data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/column-groups/">column-groups</a>, <a href="https://orwa-mahmoud.github.io/adapttable/columns/">columns</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or

--- a/apps/showcase/mantine/columns/index.html
+++ b/apps/showcase/mantine/columns/index.html
@@ -165,6 +165,36 @@ export function People({ rows, columns, layout, onLayout }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mui/columns/">Column management in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/columns/">Column management in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/columns/">Column management in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/columns/">Column management in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/columns/">Column management in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/columns/">Column management in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/columns/">Column management in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Mantine features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Mantine</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../column-groups/">Column groups in Mantine</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Mantine</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Mantine</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Mantine</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Mantine</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Mantine</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Mantine</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Mantine</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Mantine</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Mantine</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Mantine</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Mantine</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Mantine</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Mantine data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Mantine</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Mantine data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/column-management/">column-management</a>, <a href="https://orwa-mahmoud.github.io/adapttable/columns/">columns</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or

--- a/apps/showcase/mantine/editing/index.html
+++ b/apps/showcase/mantine/editing/index.html
@@ -177,7 +177,7 @@ export function People({ rows, onSave }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/editing/">editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/mantine/editing/index.html
+++ b/apps/showcase/mantine/editing/index.html
@@ -176,6 +176,36 @@ export function People({ rows, onSave }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mui/editing/">Inline cell editing in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/editing/">Inline cell editing in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/editing/">Inline cell editing in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/editing/">Inline cell editing in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/editing/">Inline cell editing in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/editing/">Inline cell editing in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/editing/">Inline cell editing in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Mantine features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Mantine</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Mantine</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Mantine</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Mantine</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Mantine</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../grouping/">Row grouping in Mantine</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Mantine</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Mantine</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Mantine</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Mantine</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Mantine</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Mantine</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Mantine</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Mantine</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Mantine data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Mantine</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Mantine data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or

--- a/apps/showcase/mantine/export/index.html
+++ b/apps/showcase/mantine/export/index.html
@@ -169,7 +169,7 @@ export function People({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-csv/">export-csv</a>, <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/mantine/export/index.html
+++ b/apps/showcase/mantine/export/index.html
@@ -168,6 +168,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mui/export/">Export and print in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/export/">Export and print in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/export/">Export and print in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/export/">Export and print in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/export/">Export and print in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/export/">Export and print in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/export/">Export and print in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Mantine features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Mantine</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Mantine</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Mantine</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Mantine</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Mantine</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Mantine</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Mantine</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Mantine</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../scale/">Large datasets in Mantine</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Mantine</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Mantine</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Mantine</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Mantine</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Mantine</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Mantine data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Mantine</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Mantine data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or

--- a/apps/showcase/mantine/filtering/index.html
+++ b/apps/showcase/mantine/filtering/index.html
@@ -173,6 +173,36 @@ export function People({ rows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mui/filtering/">Filtering in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/filtering/">Filtering in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/filtering/">Filtering in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/filtering/">Filtering in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/filtering/">Filtering in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/filtering/">Filtering in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/filtering/">Filtering in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Mantine features</h2>
+        <ul>
+          <li><a href="../columns/">Column management in Mantine</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Mantine</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Mantine</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Mantine</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Mantine</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Mantine</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Mantine</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Mantine</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Mantine</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Mantine</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Mantine</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Mantine</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Mantine</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Mantine</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Mantine data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Mantine</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Mantine data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/filtering/">filtering</a>, <a href="https://orwa-mahmoud.github.io/adapttable/filter-tree/">filter-tree</a>, <a href="https://orwa-mahmoud.github.io/adapttable/url-state/">url-state</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or

--- a/apps/showcase/mantine/formulas/index.html
+++ b/apps/showcase/mantine/formulas/index.html
@@ -175,6 +175,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mui/formulas/">Spreadsheet formulas in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/formulas/">Spreadsheet formulas in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/formulas/">Spreadsheet formulas in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/formulas/">Spreadsheet formulas in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/formulas/">Spreadsheet formulas in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/formulas/">Spreadsheet formulas in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/formulas/">Spreadsheet formulas in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Mantine features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Mantine</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Mantine</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Mantine</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Mantine</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Mantine</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Mantine</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Mantine</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Mantine</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Mantine</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Mantine</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Mantine</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Mantine</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Mantine</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Mantine</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../rtl/">Right-to-left Mantine data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Mantine</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Mantine data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/formulas/">formulas</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or

--- a/apps/showcase/mantine/grouping/index.html
+++ b/apps/showcase/mantine/grouping/index.html
@@ -169,6 +169,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mui/grouping/">Row grouping in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/grouping/">Row grouping in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/grouping/">Row grouping in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/grouping/">Row grouping in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/grouping/">Row grouping in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/grouping/">Row grouping in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/grouping/">Row grouping in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Mantine features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Mantine</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Mantine</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Mantine</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Mantine</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Mantine</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Mantine</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../nested-tables/">Nested tables in Mantine</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Mantine</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Mantine</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Mantine</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Mantine</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Mantine</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Mantine</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Mantine</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Mantine data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Mantine</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Mantine data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-grouping/">row-grouping</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or

--- a/apps/showcase/mantine/grouping/index.html
+++ b/apps/showcase/mantine/grouping/index.html
@@ -170,7 +170,7 @@ export function People({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/grouping/">grouping</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-grouping/">row-grouping</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/mantine/index.html
+++ b/apps/showcase/mantine/index.html
@@ -169,6 +169,17 @@
           <li><a href="./realtime/">Live updates in Mantine</a> — Rows change while you read them. Sort and selection hold.</li>
           <li><a href="./accessibility/">Accessible Mantine data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
         </ul>
+        <h2>The same table, in seven other kits</h2>
+        <p>Switching kit changes the components, never the model — the props on this page are the props there.</p>
+        <ul>
+          <li><a href="../mui/">AdaptTable for MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../chakra/">AdaptTable for Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../antd/">AdaptTable for Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../radix/">AdaptTable for Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../base-ui/">AdaptTable for Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../shadcn/">AdaptTable for shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../tailwind/">AdaptTable for Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/getting-started/">getting started</a>. Or
           open <a href="/adapttable/demo/">the live demo</a> and switch kits on

--- a/apps/showcase/mantine/mobile-cards/index.html
+++ b/apps/showcase/mantine/mobile-cards/index.html
@@ -166,6 +166,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mui/mobile-cards/">Mobile cards in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/mobile-cards/">Mobile cards in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/mobile-cards/">Mobile cards in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/mobile-cards/">Mobile cards in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/mobile-cards/">Mobile cards in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/mobile-cards/">Mobile cards in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/mobile-cards/">Mobile cards in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Mantine features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Mantine</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Mantine</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Mantine</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Mantine</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Mantine</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Mantine</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Mantine</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Mantine</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Mantine</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Mantine</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Mantine</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../pivot/">Pivot tables in Mantine</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Mantine</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Mantine</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Mantine data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Mantine</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Mantine data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/mobile/">mobile</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or

--- a/apps/showcase/mantine/nested-tables/index.html
+++ b/apps/showcase/mantine/nested-tables/index.html
@@ -172,6 +172,36 @@ export function People({ rows, columns, orderColumns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mui/nested-tables/">Nested tables in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/nested-tables/">Nested tables in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/nested-tables/">Nested tables in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/nested-tables/">Nested tables in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/nested-tables/">Nested tables in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/nested-tables/">Nested tables in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/nested-tables/">Nested tables in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Mantine features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Mantine</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Mantine</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Mantine</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Mantine</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Mantine</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Mantine</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Mantine</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../export/">Export and print in Mantine</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Mantine</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Mantine</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Mantine</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Mantine</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Mantine</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Mantine</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Mantine data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Mantine</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Mantine data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/tree-data/">tree-data</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-expansion/">row-expansion</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or

--- a/apps/showcase/mantine/pivot/index.html
+++ b/apps/showcase/mantine/pivot/index.html
@@ -173,6 +173,36 @@ export function Spend({ rows, fields }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mui/pivot/">Pivot tables in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/pivot/">Pivot tables in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/pivot/">Pivot tables in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/pivot/">Pivot tables in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/pivot/">Pivot tables in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/pivot/">Pivot tables in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/pivot/">Pivot tables in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Mantine features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Mantine</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Mantine</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Mantine</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Mantine</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Mantine</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Mantine</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Mantine</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Mantine</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Mantine</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Mantine</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Mantine</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Mantine</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../saved-views/">Saved views in Mantine</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Mantine</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Mantine data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Mantine</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Mantine data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/pivot/">pivot</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or

--- a/apps/showcase/mantine/realtime/index.html
+++ b/apps/showcase/mantine/realtime/index.html
@@ -170,6 +170,36 @@ export function People({ rows, columns, setRows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mui/realtime/">Live updates in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/realtime/">Live updates in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/realtime/">Live updates in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/realtime/">Live updates in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/realtime/">Live updates in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/realtime/">Live updates in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/realtime/">Live updates in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Mantine features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Mantine</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Mantine</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Mantine</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Mantine</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Mantine</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Mantine</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Mantine</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Mantine</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Mantine</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Mantine</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Mantine</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Mantine</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Mantine</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Mantine</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Mantine</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Mantine data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../accessibility/">Accessible Mantine data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/realtime/">realtime</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or

--- a/apps/showcase/mantine/rows/index.html
+++ b/apps/showcase/mantine/rows/index.html
@@ -165,6 +165,36 @@ export function People({ rows, columns, onReorder, setPinned, spanTeam }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mui/rows/">Rows in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/rows/">Rows in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/rows/">Rows in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/rows/">Rows in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/rows/">Rows in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/rows/">Rows in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/rows/">Rows in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Mantine features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Mantine</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Mantine</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Mantine</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Mantine</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../editing/">Inline cell editing in Mantine</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Mantine</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Mantine</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Mantine</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Mantine</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Mantine</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Mantine</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Mantine</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Mantine</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Mantine</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Mantine data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Mantine</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Mantine data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-pinning/">row-pinning</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-reordering/">row-reordering</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-spanning/">row-spanning</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or

--- a/apps/showcase/mantine/rtl/index.html
+++ b/apps/showcase/mantine/rtl/index.html
@@ -163,6 +163,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mui/rtl/">Right-to-left MUI data table</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/rtl/">Right-to-left Chakra data table</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/rtl/">Right-to-left Ant Design data table</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/rtl/">Right-to-left Radix data table</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/rtl/">Right-to-left Base UI data table</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/rtl/">Right-to-left shadcn data table</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/rtl/">Right-to-left Tailwind data table</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Mantine features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Mantine</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Mantine</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Mantine</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Mantine</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Mantine</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Mantine</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Mantine</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Mantine</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Mantine</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Mantine</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Mantine</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Mantine</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Mantine</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Mantine</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Mantine</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../realtime/">Live updates in Mantine</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Mantine data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/i18n-rtl/">i18n-rtl</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or

--- a/apps/showcase/mantine/saved-views/index.html
+++ b/apps/showcase/mantine/saved-views/index.html
@@ -181,6 +181,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mui/saved-views/">Saved views in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/saved-views/">Saved views in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/saved-views/">Saved views in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/saved-views/">Saved views in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/saved-views/">Saved views in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/saved-views/">Saved views in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/saved-views/">Saved views in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Mantine features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Mantine</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Mantine</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Mantine</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Mantine</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Mantine</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Mantine</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Mantine</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Mantine</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Mantine</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Mantine</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Mantine</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Mantine</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Mantine</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Mantine</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Mantine data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Mantine</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Mantine data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/saved-views/">saved-views</a>, <a href="https://orwa-mahmoud.github.io/adapttable/url-state/">url-state</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or

--- a/apps/showcase/mantine/scale/index.html
+++ b/apps/showcase/mantine/scale/index.html
@@ -165,6 +165,36 @@ export function Ledger({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mui/scale/">Large datasets in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/scale/">Large datasets in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/scale/">Large datasets in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/scale/">Large datasets in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/scale/">Large datasets in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/scale/">Large datasets in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/scale/">Large datasets in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Mantine features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Mantine</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Mantine</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Mantine</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Mantine</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Mantine</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Mantine</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Mantine</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Mantine</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Mantine</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../tree/">Tree data in Mantine</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Mantine</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Mantine</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Mantine</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Mantine</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Mantine data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Mantine</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Mantine data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or

--- a/apps/showcase/mantine/scale/index.html
+++ b/apps/showcase/mantine/scale/index.html
@@ -166,7 +166,7 @@ export function Ledger({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/performance/">performance</a>, <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/mantine/selection/index.html
+++ b/apps/showcase/mantine/selection/index.html
@@ -169,6 +169,36 @@ export function People({ rows, columns, onArchive }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mui/selection/">Row selection in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/selection/">Row selection in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/selection/">Row selection in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/selection/">Row selection in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/selection/">Row selection in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/selection/">Row selection in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/selection/">Row selection in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Mantine features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Mantine</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Mantine</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Mantine</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../rows/">Rows in Mantine</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Mantine</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Mantine</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Mantine</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Mantine</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Mantine</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Mantine</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Mantine</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Mantine</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Mantine</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Mantine</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Mantine data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Mantine</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Mantine data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or

--- a/apps/showcase/mantine/selection/index.html
+++ b/apps/showcase/mantine/selection/index.html
@@ -170,7 +170,7 @@ export function People({ rows, columns, onArchive }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>, <a href="https://orwa-mahmoud.github.io/adapttable/bulk-actions/">bulk-actions</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/mantine/tree/index.html
+++ b/apps/showcase/mantine/tree/index.html
@@ -164,6 +164,36 @@ export function Org({ people, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mantine @adapttable/core @mantine/core @mantine/hooks</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mui/tree/">Tree data in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/tree/">Tree data in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/tree/">Tree data in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/tree/">Tree data in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/tree/">Tree data in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/tree/">Tree data in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/tree/">Tree data in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Mantine features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Mantine</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Mantine</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Mantine</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Mantine</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Mantine</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Mantine</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Mantine</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Mantine</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Mantine</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Mantine</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Mantine</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Mantine</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Mantine</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Mantine</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Mantine data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Mantine</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Mantine data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/tree-data/">tree-data</a>. More of this kit:
           <a href="../">AdaptTable for Mantine</a>, or

--- a/apps/showcase/matrix.mjs
+++ b/apps/showcase/matrix.mjs
@@ -507,7 +507,7 @@ export function People({ rows, onSave }) {
       tailwind:
         "The editor is a native input or select carrying the map's field classes with an indigo focus ring; the validation and rollback parts carry no classes in this map, so a rejected commit reads as browser-default text.",
     },
-    docs: ["editing", "cell-navigation"],
+    docs: ["cell-editing", "cell-navigation"],
   },
   {
     slug: "tree",
@@ -645,7 +645,7 @@ export function Ledger({ rows, columns }) {
       tailwind:
         "The map paints the header and pinned cells opaque per element rather than through a token, which is what stops scrolled rows showing through them, and the scroll box contains its own overscroll.",
     },
-    docs: ["performance", "virtualization"],
+    docs: ["virtualization"],
   },
   {
     slug: "columns",
@@ -806,7 +806,7 @@ export function People({ rows, columns }) {
       tailwind:
         "The button and its spinner are both plain elements the map styles — the same construction shadcn's preset uses, in this map's own neutrals.",
     },
-    docs: ["export-csv", "export-pdf"],
+    docs: ["export-pdf"],
   },
   {
     slug: "selection",
@@ -856,7 +856,7 @@ export function People({ rows, columns, onArchive }) {
       tailwind:
         "The boxes are native checkboxes tinted indigo, a selected row takes an indigo wash that has its own dark variant, and the bulk bar is styled to match.",
     },
-    docs: ["selection", "bulk-actions"],
+    docs: ["selection"],
   },
   {
     slug: "grouping",
@@ -906,7 +906,7 @@ export function People({ rows, columns }) {
       tailwind:
         "The group row, toggle, label, count and aggregate all carry the map's classes with a dark variant; group footers and the show-more row are not in the map, so those two read as browser defaults.",
     },
-    docs: ["grouping"],
+    docs: ["row-grouping"],
   },
   {
     slug: "column-groups",

--- a/apps/showcase/mui/accessibility/index.html
+++ b/apps/showcase/mui/accessibility/index.html
@@ -163,6 +163,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/accessibility/">Accessible Mantine data table</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../chakra/accessibility/">Accessible Chakra data table</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/accessibility/">Accessible Ant Design data table</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/accessibility/">Accessible Radix data table</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/accessibility/">Accessible Base UI data table</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/accessibility/">Accessible shadcn data table</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/accessibility/">Accessible Tailwind data table</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More MUI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in MUI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in MUI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in MUI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in MUI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in MUI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in MUI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in MUI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in MUI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in MUI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in MUI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in MUI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in MUI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in MUI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in MUI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in MUI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left MUI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in MUI</a> — Rows change while you read them. Sort and selection hold.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/accessibility/">accessibility</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or

--- a/apps/showcase/mui/column-groups/index.html
+++ b/apps/showcase/mui/column-groups/index.html
@@ -189,6 +189,36 @@ export function People({ rows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/column-groups/">Column groups in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../chakra/column-groups/">Column groups in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/column-groups/">Column groups in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/column-groups/">Column groups in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/column-groups/">Column groups in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/column-groups/">Column groups in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/column-groups/">Column groups in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More MUI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in MUI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in MUI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../selection/">Row selection in MUI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in MUI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in MUI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in MUI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in MUI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in MUI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in MUI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in MUI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in MUI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in MUI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in MUI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in MUI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left MUI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in MUI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible MUI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/column-groups/">column-groups</a>, <a href="https://orwa-mahmoud.github.io/adapttable/columns/">columns</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or

--- a/apps/showcase/mui/columns/index.html
+++ b/apps/showcase/mui/columns/index.html
@@ -165,6 +165,36 @@ export function People({ rows, columns, layout, onLayout }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/columns/">Column management in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../chakra/columns/">Column management in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/columns/">Column management in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/columns/">Column management in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/columns/">Column management in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/columns/">Column management in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/columns/">Column management in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More MUI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in MUI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../column-groups/">Column groups in MUI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in MUI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in MUI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in MUI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in MUI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in MUI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in MUI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in MUI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in MUI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in MUI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in MUI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in MUI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in MUI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left MUI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in MUI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible MUI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/column-management/">column-management</a>, <a href="https://orwa-mahmoud.github.io/adapttable/columns/">columns</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or

--- a/apps/showcase/mui/editing/index.html
+++ b/apps/showcase/mui/editing/index.html
@@ -177,7 +177,7 @@ export function People({ rows, onSave }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/editing/">editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/mui/editing/index.html
+++ b/apps/showcase/mui/editing/index.html
@@ -176,6 +176,36 @@ export function People({ rows, onSave }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/editing/">Inline cell editing in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../chakra/editing/">Inline cell editing in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/editing/">Inline cell editing in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/editing/">Inline cell editing in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/editing/">Inline cell editing in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/editing/">Inline cell editing in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/editing/">Inline cell editing in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More MUI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in MUI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in MUI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in MUI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in MUI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in MUI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../grouping/">Row grouping in MUI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in MUI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in MUI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in MUI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in MUI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in MUI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in MUI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in MUI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in MUI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left MUI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in MUI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible MUI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or

--- a/apps/showcase/mui/export/index.html
+++ b/apps/showcase/mui/export/index.html
@@ -169,7 +169,7 @@ export function People({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-csv/">export-csv</a>, <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/mui/export/index.html
+++ b/apps/showcase/mui/export/index.html
@@ -168,6 +168,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/export/">Export and print in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../chakra/export/">Export and print in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/export/">Export and print in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/export/">Export and print in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/export/">Export and print in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/export/">Export and print in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/export/">Export and print in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More MUI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in MUI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in MUI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in MUI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in MUI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in MUI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in MUI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in MUI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in MUI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../scale/">Large datasets in MUI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in MUI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in MUI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in MUI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in MUI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in MUI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left MUI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in MUI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible MUI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or

--- a/apps/showcase/mui/filtering/index.html
+++ b/apps/showcase/mui/filtering/index.html
@@ -173,6 +173,36 @@ export function People({ rows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/filtering/">Filtering in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../chakra/filtering/">Filtering in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/filtering/">Filtering in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/filtering/">Filtering in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/filtering/">Filtering in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/filtering/">Filtering in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/filtering/">Filtering in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More MUI features</h2>
+        <ul>
+          <li><a href="../columns/">Column management in MUI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in MUI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in MUI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in MUI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in MUI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in MUI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in MUI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in MUI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in MUI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in MUI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in MUI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in MUI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in MUI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in MUI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left MUI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in MUI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible MUI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/filtering/">filtering</a>, <a href="https://orwa-mahmoud.github.io/adapttable/filter-tree/">filter-tree</a>, <a href="https://orwa-mahmoud.github.io/adapttable/url-state/">url-state</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or

--- a/apps/showcase/mui/formulas/index.html
+++ b/apps/showcase/mui/formulas/index.html
@@ -175,6 +175,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/formulas/">Spreadsheet formulas in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../chakra/formulas/">Spreadsheet formulas in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/formulas/">Spreadsheet formulas in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/formulas/">Spreadsheet formulas in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/formulas/">Spreadsheet formulas in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/formulas/">Spreadsheet formulas in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/formulas/">Spreadsheet formulas in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More MUI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in MUI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in MUI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in MUI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in MUI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in MUI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in MUI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in MUI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in MUI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in MUI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in MUI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in MUI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in MUI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in MUI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in MUI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../rtl/">Right-to-left MUI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in MUI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible MUI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/formulas/">formulas</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or

--- a/apps/showcase/mui/grouping/index.html
+++ b/apps/showcase/mui/grouping/index.html
@@ -170,7 +170,7 @@ export function People({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/grouping/">grouping</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-grouping/">row-grouping</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/mui/grouping/index.html
+++ b/apps/showcase/mui/grouping/index.html
@@ -169,6 +169,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/grouping/">Row grouping in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../chakra/grouping/">Row grouping in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/grouping/">Row grouping in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/grouping/">Row grouping in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/grouping/">Row grouping in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/grouping/">Row grouping in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/grouping/">Row grouping in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More MUI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in MUI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in MUI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in MUI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in MUI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in MUI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in MUI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../nested-tables/">Nested tables in MUI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in MUI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in MUI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in MUI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in MUI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in MUI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in MUI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in MUI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left MUI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in MUI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible MUI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-grouping/">row-grouping</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or

--- a/apps/showcase/mui/index.html
+++ b/apps/showcase/mui/index.html
@@ -169,6 +169,17 @@
           <li><a href="./realtime/">Live updates in MUI</a> — Rows change while you read them. Sort and selection hold.</li>
           <li><a href="./accessibility/">Accessible MUI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
         </ul>
+        <h2>The same table, in seven other kits</h2>
+        <p>Switching kit changes the components, never the model — the props on this page are the props there.</p>
+        <ul>
+          <li><a href="../mantine/">AdaptTable for Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../chakra/">AdaptTable for Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../antd/">AdaptTable for Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../radix/">AdaptTable for Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../base-ui/">AdaptTable for Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../shadcn/">AdaptTable for shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../tailwind/">AdaptTable for Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/getting-started/">getting started</a>. Or
           open <a href="/adapttable/demo/">the live demo</a> and switch kits on

--- a/apps/showcase/mui/mobile-cards/index.html
+++ b/apps/showcase/mui/mobile-cards/index.html
@@ -166,6 +166,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/mobile-cards/">Mobile cards in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../chakra/mobile-cards/">Mobile cards in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/mobile-cards/">Mobile cards in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/mobile-cards/">Mobile cards in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/mobile-cards/">Mobile cards in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/mobile-cards/">Mobile cards in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/mobile-cards/">Mobile cards in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More MUI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in MUI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in MUI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in MUI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in MUI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in MUI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in MUI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in MUI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in MUI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in MUI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in MUI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in MUI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../pivot/">Pivot tables in MUI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in MUI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in MUI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left MUI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in MUI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible MUI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/mobile/">mobile</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or

--- a/apps/showcase/mui/nested-tables/index.html
+++ b/apps/showcase/mui/nested-tables/index.html
@@ -172,6 +172,36 @@ export function People({ rows, columns, orderColumns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/nested-tables/">Nested tables in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../chakra/nested-tables/">Nested tables in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/nested-tables/">Nested tables in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/nested-tables/">Nested tables in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/nested-tables/">Nested tables in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/nested-tables/">Nested tables in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/nested-tables/">Nested tables in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More MUI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in MUI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in MUI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in MUI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in MUI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in MUI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in MUI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in MUI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../export/">Export and print in MUI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in MUI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in MUI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in MUI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in MUI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in MUI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in MUI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left MUI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in MUI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible MUI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/tree-data/">tree-data</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-expansion/">row-expansion</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or

--- a/apps/showcase/mui/pivot/index.html
+++ b/apps/showcase/mui/pivot/index.html
@@ -173,6 +173,36 @@ export function Spend({ rows, fields }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/pivot/">Pivot tables in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../chakra/pivot/">Pivot tables in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/pivot/">Pivot tables in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/pivot/">Pivot tables in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/pivot/">Pivot tables in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/pivot/">Pivot tables in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/pivot/">Pivot tables in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More MUI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in MUI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in MUI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in MUI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in MUI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in MUI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in MUI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in MUI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in MUI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in MUI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in MUI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in MUI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in MUI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../saved-views/">Saved views in MUI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in MUI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left MUI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in MUI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible MUI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/pivot/">pivot</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or

--- a/apps/showcase/mui/realtime/index.html
+++ b/apps/showcase/mui/realtime/index.html
@@ -170,6 +170,36 @@ export function People({ rows, columns, setRows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/realtime/">Live updates in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../chakra/realtime/">Live updates in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/realtime/">Live updates in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/realtime/">Live updates in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/realtime/">Live updates in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/realtime/">Live updates in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/realtime/">Live updates in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More MUI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in MUI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in MUI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in MUI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in MUI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in MUI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in MUI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in MUI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in MUI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in MUI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in MUI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in MUI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in MUI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in MUI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in MUI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in MUI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left MUI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../accessibility/">Accessible MUI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/realtime/">realtime</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or

--- a/apps/showcase/mui/rows/index.html
+++ b/apps/showcase/mui/rows/index.html
@@ -165,6 +165,36 @@ export function People({ rows, columns, onReorder, setPinned, spanTeam }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/rows/">Rows in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../chakra/rows/">Rows in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/rows/">Rows in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/rows/">Rows in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/rows/">Rows in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/rows/">Rows in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/rows/">Rows in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More MUI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in MUI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in MUI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in MUI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in MUI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../editing/">Inline cell editing in MUI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in MUI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in MUI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in MUI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in MUI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in MUI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in MUI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in MUI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in MUI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in MUI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left MUI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in MUI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible MUI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-pinning/">row-pinning</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-reordering/">row-reordering</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-spanning/">row-spanning</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or

--- a/apps/showcase/mui/rtl/index.html
+++ b/apps/showcase/mui/rtl/index.html
@@ -163,6 +163,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/rtl/">Right-to-left Mantine data table</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../chakra/rtl/">Right-to-left Chakra data table</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/rtl/">Right-to-left Ant Design data table</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/rtl/">Right-to-left Radix data table</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/rtl/">Right-to-left Base UI data table</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/rtl/">Right-to-left shadcn data table</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/rtl/">Right-to-left Tailwind data table</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More MUI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in MUI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in MUI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in MUI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in MUI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in MUI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in MUI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in MUI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in MUI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in MUI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in MUI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in MUI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in MUI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in MUI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in MUI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in MUI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../realtime/">Live updates in MUI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible MUI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/i18n-rtl/">i18n-rtl</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or

--- a/apps/showcase/mui/saved-views/index.html
+++ b/apps/showcase/mui/saved-views/index.html
@@ -181,6 +181,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/saved-views/">Saved views in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../chakra/saved-views/">Saved views in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/saved-views/">Saved views in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/saved-views/">Saved views in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/saved-views/">Saved views in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/saved-views/">Saved views in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/saved-views/">Saved views in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More MUI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in MUI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in MUI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in MUI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in MUI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in MUI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in MUI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in MUI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in MUI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in MUI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in MUI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in MUI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in MUI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in MUI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in MUI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left MUI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in MUI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible MUI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/saved-views/">saved-views</a>, <a href="https://orwa-mahmoud.github.io/adapttable/url-state/">url-state</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or

--- a/apps/showcase/mui/scale/index.html
+++ b/apps/showcase/mui/scale/index.html
@@ -165,6 +165,36 @@ export function Ledger({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/scale/">Large datasets in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../chakra/scale/">Large datasets in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/scale/">Large datasets in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/scale/">Large datasets in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/scale/">Large datasets in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/scale/">Large datasets in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/scale/">Large datasets in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More MUI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in MUI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in MUI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in MUI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in MUI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in MUI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in MUI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in MUI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in MUI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in MUI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../tree/">Tree data in MUI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in MUI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in MUI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in MUI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in MUI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left MUI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in MUI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible MUI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or

--- a/apps/showcase/mui/scale/index.html
+++ b/apps/showcase/mui/scale/index.html
@@ -166,7 +166,7 @@ export function Ledger({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/performance/">performance</a>, <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/mui/selection/index.html
+++ b/apps/showcase/mui/selection/index.html
@@ -169,6 +169,36 @@ export function People({ rows, columns, onArchive }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/selection/">Row selection in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../chakra/selection/">Row selection in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/selection/">Row selection in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/selection/">Row selection in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/selection/">Row selection in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/selection/">Row selection in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/selection/">Row selection in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More MUI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in MUI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in MUI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in MUI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../rows/">Rows in MUI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in MUI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in MUI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in MUI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in MUI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in MUI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in MUI</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in MUI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in MUI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in MUI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in MUI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left MUI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in MUI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible MUI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or

--- a/apps/showcase/mui/selection/index.html
+++ b/apps/showcase/mui/selection/index.html
@@ -170,7 +170,7 @@ export function People({ rows, columns, onArchive }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>, <a href="https://orwa-mahmoud.github.io/adapttable/bulk-actions/">bulk-actions</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/mui/tree/index.html
+++ b/apps/showcase/mui/tree/index.html
@@ -164,6 +164,36 @@ export function Org({ people, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/mui @adapttable/core @mui/material</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/tree/">Tree data in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../chakra/tree/">Tree data in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/tree/">Tree data in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/tree/">Tree data in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/tree/">Tree data in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/tree/">Tree data in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/tree/">Tree data in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More MUI features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in MUI</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in MUI</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in MUI</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in MUI</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in MUI</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in MUI</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in MUI</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in MUI</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in MUI</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in MUI</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../mobile-cards/">Mobile cards in MUI</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in MUI</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in MUI</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in MUI</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left MUI data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in MUI</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible MUI data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/tree-data/">tree-data</a>. More of this kit:
           <a href="../">AdaptTable for MUI</a>, or

--- a/apps/showcase/radix/accessibility/index.html
+++ b/apps/showcase/radix/accessibility/index.html
@@ -163,6 +163,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/accessibility/">Accessible Mantine data table</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/accessibility/">Accessible MUI data table</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/accessibility/">Accessible Chakra data table</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/accessibility/">Accessible Ant Design data table</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../base-ui/accessibility/">Accessible Base UI data table</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/accessibility/">Accessible shadcn data table</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/accessibility/">Accessible Tailwind data table</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Radix features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Radix</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Radix</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Radix</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Radix</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Radix</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Radix</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Radix</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Radix</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Radix</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Radix</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Radix</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Radix</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Radix</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Radix</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Radix</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Radix data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Radix</a> — Rows change while you read them. Sort and selection hold.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/accessibility/">accessibility</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or

--- a/apps/showcase/radix/column-groups/index.html
+++ b/apps/showcase/radix/column-groups/index.html
@@ -189,6 +189,36 @@ export function People({ rows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/column-groups/">Column groups in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/column-groups/">Column groups in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/column-groups/">Column groups in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/column-groups/">Column groups in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../base-ui/column-groups/">Column groups in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/column-groups/">Column groups in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/column-groups/">Column groups in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Radix features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Radix</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Radix</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../selection/">Row selection in Radix</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Radix</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Radix</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Radix</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Radix</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Radix</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Radix</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Radix</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Radix</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Radix</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Radix</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Radix</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Radix data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Radix</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Radix data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/column-groups/">column-groups</a>, <a href="https://orwa-mahmoud.github.io/adapttable/columns/">columns</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or

--- a/apps/showcase/radix/columns/index.html
+++ b/apps/showcase/radix/columns/index.html
@@ -165,6 +165,36 @@ export function People({ rows, columns, layout, onLayout }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/columns/">Column management in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/columns/">Column management in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/columns/">Column management in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/columns/">Column management in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../base-ui/columns/">Column management in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/columns/">Column management in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/columns/">Column management in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Radix features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Radix</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../column-groups/">Column groups in Radix</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Radix</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Radix</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Radix</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Radix</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Radix</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Radix</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Radix</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Radix</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Radix</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Radix</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Radix</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Radix</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Radix data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Radix</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Radix data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/column-management/">column-management</a>, <a href="https://orwa-mahmoud.github.io/adapttable/columns/">columns</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or

--- a/apps/showcase/radix/editing/index.html
+++ b/apps/showcase/radix/editing/index.html
@@ -176,6 +176,36 @@ export function People({ rows, onSave }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/editing/">Inline cell editing in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/editing/">Inline cell editing in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/editing/">Inline cell editing in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/editing/">Inline cell editing in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../base-ui/editing/">Inline cell editing in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/editing/">Inline cell editing in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/editing/">Inline cell editing in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Radix features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Radix</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Radix</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Radix</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Radix</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Radix</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../grouping/">Row grouping in Radix</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Radix</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Radix</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Radix</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Radix</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Radix</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Radix</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Radix</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Radix</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Radix data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Radix</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Radix data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or

--- a/apps/showcase/radix/editing/index.html
+++ b/apps/showcase/radix/editing/index.html
@@ -177,7 +177,7 @@ export function People({ rows, onSave }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/editing/">editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/radix/export/index.html
+++ b/apps/showcase/radix/export/index.html
@@ -168,6 +168,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/export/">Export and print in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/export/">Export and print in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/export/">Export and print in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/export/">Export and print in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../base-ui/export/">Export and print in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/export/">Export and print in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/export/">Export and print in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Radix features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Radix</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Radix</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Radix</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Radix</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Radix</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Radix</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Radix</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Radix</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../scale/">Large datasets in Radix</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Radix</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Radix</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Radix</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Radix</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Radix</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Radix data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Radix</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Radix data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or

--- a/apps/showcase/radix/export/index.html
+++ b/apps/showcase/radix/export/index.html
@@ -169,7 +169,7 @@ export function People({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-csv/">export-csv</a>, <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/radix/filtering/index.html
+++ b/apps/showcase/radix/filtering/index.html
@@ -173,6 +173,36 @@ export function People({ rows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/filtering/">Filtering in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/filtering/">Filtering in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/filtering/">Filtering in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/filtering/">Filtering in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../base-ui/filtering/">Filtering in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/filtering/">Filtering in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/filtering/">Filtering in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Radix features</h2>
+        <ul>
+          <li><a href="../columns/">Column management in Radix</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Radix</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Radix</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Radix</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Radix</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Radix</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Radix</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Radix</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Radix</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Radix</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Radix</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Radix</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Radix</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Radix</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Radix data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Radix</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Radix data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/filtering/">filtering</a>, <a href="https://orwa-mahmoud.github.io/adapttable/filter-tree/">filter-tree</a>, <a href="https://orwa-mahmoud.github.io/adapttable/url-state/">url-state</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or

--- a/apps/showcase/radix/formulas/index.html
+++ b/apps/showcase/radix/formulas/index.html
@@ -175,6 +175,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/formulas/">Spreadsheet formulas in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/formulas/">Spreadsheet formulas in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/formulas/">Spreadsheet formulas in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/formulas/">Spreadsheet formulas in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../base-ui/formulas/">Spreadsheet formulas in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/formulas/">Spreadsheet formulas in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/formulas/">Spreadsheet formulas in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Radix features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Radix</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Radix</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Radix</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Radix</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Radix</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Radix</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Radix</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Radix</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Radix</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Radix</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Radix</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Radix</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Radix</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Radix</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../rtl/">Right-to-left Radix data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Radix</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Radix data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/formulas/">formulas</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or

--- a/apps/showcase/radix/grouping/index.html
+++ b/apps/showcase/radix/grouping/index.html
@@ -169,6 +169,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/grouping/">Row grouping in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/grouping/">Row grouping in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/grouping/">Row grouping in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/grouping/">Row grouping in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../base-ui/grouping/">Row grouping in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/grouping/">Row grouping in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/grouping/">Row grouping in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Radix features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Radix</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Radix</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Radix</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Radix</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Radix</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Radix</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../nested-tables/">Nested tables in Radix</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Radix</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Radix</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Radix</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Radix</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Radix</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Radix</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Radix</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Radix data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Radix</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Radix data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-grouping/">row-grouping</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or

--- a/apps/showcase/radix/grouping/index.html
+++ b/apps/showcase/radix/grouping/index.html
@@ -170,7 +170,7 @@ export function People({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/grouping/">grouping</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-grouping/">row-grouping</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/radix/index.html
+++ b/apps/showcase/radix/index.html
@@ -169,6 +169,17 @@
           <li><a href="./realtime/">Live updates in Radix</a> — Rows change while you read them. Sort and selection hold.</li>
           <li><a href="./accessibility/">Accessible Radix data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
         </ul>
+        <h2>The same table, in seven other kits</h2>
+        <p>Switching kit changes the components, never the model — the props on this page are the props there.</p>
+        <ul>
+          <li><a href="../mantine/">AdaptTable for Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../mui/">AdaptTable for MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../chakra/">AdaptTable for Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../antd/">AdaptTable for Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../base-ui/">AdaptTable for Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../shadcn/">AdaptTable for shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../tailwind/">AdaptTable for Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/getting-started/">getting started</a>. Or
           open <a href="/adapttable/demo/">the live demo</a> and switch kits on

--- a/apps/showcase/radix/mobile-cards/index.html
+++ b/apps/showcase/radix/mobile-cards/index.html
@@ -166,6 +166,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/mobile-cards/">Mobile cards in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/mobile-cards/">Mobile cards in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/mobile-cards/">Mobile cards in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/mobile-cards/">Mobile cards in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../base-ui/mobile-cards/">Mobile cards in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/mobile-cards/">Mobile cards in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/mobile-cards/">Mobile cards in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Radix features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Radix</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Radix</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Radix</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Radix</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Radix</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Radix</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Radix</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Radix</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Radix</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Radix</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Radix</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../pivot/">Pivot tables in Radix</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Radix</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Radix</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Radix data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Radix</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Radix data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/mobile/">mobile</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or

--- a/apps/showcase/radix/nested-tables/index.html
+++ b/apps/showcase/radix/nested-tables/index.html
@@ -172,6 +172,36 @@ export function People({ rows, columns, orderColumns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/nested-tables/">Nested tables in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/nested-tables/">Nested tables in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/nested-tables/">Nested tables in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/nested-tables/">Nested tables in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../base-ui/nested-tables/">Nested tables in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/nested-tables/">Nested tables in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/nested-tables/">Nested tables in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Radix features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Radix</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Radix</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Radix</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Radix</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Radix</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Radix</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Radix</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../export/">Export and print in Radix</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Radix</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Radix</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Radix</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Radix</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Radix</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Radix</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Radix data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Radix</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Radix data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/tree-data/">tree-data</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-expansion/">row-expansion</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or

--- a/apps/showcase/radix/pivot/index.html
+++ b/apps/showcase/radix/pivot/index.html
@@ -173,6 +173,36 @@ export function Spend({ rows, fields }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/pivot/">Pivot tables in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/pivot/">Pivot tables in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/pivot/">Pivot tables in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/pivot/">Pivot tables in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../base-ui/pivot/">Pivot tables in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/pivot/">Pivot tables in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/pivot/">Pivot tables in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Radix features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Radix</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Radix</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Radix</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Radix</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Radix</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Radix</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Radix</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Radix</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Radix</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Radix</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Radix</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Radix</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../saved-views/">Saved views in Radix</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Radix</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Radix data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Radix</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Radix data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/pivot/">pivot</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or

--- a/apps/showcase/radix/realtime/index.html
+++ b/apps/showcase/radix/realtime/index.html
@@ -170,6 +170,36 @@ export function People({ rows, columns, setRows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/realtime/">Live updates in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/realtime/">Live updates in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/realtime/">Live updates in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/realtime/">Live updates in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../base-ui/realtime/">Live updates in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/realtime/">Live updates in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/realtime/">Live updates in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Radix features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Radix</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Radix</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Radix</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Radix</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Radix</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Radix</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Radix</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Radix</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Radix</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Radix</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Radix</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Radix</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Radix</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Radix</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Radix</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Radix data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../accessibility/">Accessible Radix data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/realtime/">realtime</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or

--- a/apps/showcase/radix/rows/index.html
+++ b/apps/showcase/radix/rows/index.html
@@ -165,6 +165,36 @@ export function People({ rows, columns, onReorder, setPinned, spanTeam }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/rows/">Rows in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/rows/">Rows in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/rows/">Rows in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/rows/">Rows in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../base-ui/rows/">Rows in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/rows/">Rows in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/rows/">Rows in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Radix features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Radix</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Radix</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Radix</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Radix</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../editing/">Inline cell editing in Radix</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Radix</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Radix</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Radix</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Radix</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Radix</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Radix</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Radix</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Radix</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Radix</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Radix data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Radix</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Radix data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-pinning/">row-pinning</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-reordering/">row-reordering</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-spanning/">row-spanning</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or

--- a/apps/showcase/radix/rtl/index.html
+++ b/apps/showcase/radix/rtl/index.html
@@ -163,6 +163,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/rtl/">Right-to-left Mantine data table</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/rtl/">Right-to-left MUI data table</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/rtl/">Right-to-left Chakra data table</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/rtl/">Right-to-left Ant Design data table</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../base-ui/rtl/">Right-to-left Base UI data table</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/rtl/">Right-to-left shadcn data table</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/rtl/">Right-to-left Tailwind data table</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Radix features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Radix</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Radix</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Radix</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Radix</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Radix</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Radix</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Radix</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Radix</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Radix</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Radix</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Radix</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Radix</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Radix</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Radix</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Radix</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../realtime/">Live updates in Radix</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Radix data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/i18n-rtl/">i18n-rtl</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or

--- a/apps/showcase/radix/saved-views/index.html
+++ b/apps/showcase/radix/saved-views/index.html
@@ -181,6 +181,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/saved-views/">Saved views in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/saved-views/">Saved views in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/saved-views/">Saved views in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/saved-views/">Saved views in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../base-ui/saved-views/">Saved views in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/saved-views/">Saved views in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/saved-views/">Saved views in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Radix features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Radix</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Radix</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Radix</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Radix</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Radix</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Radix</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Radix</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Radix</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Radix</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Radix</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Radix</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Radix</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Radix</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Radix</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Radix data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Radix</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Radix data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/saved-views/">saved-views</a>, <a href="https://orwa-mahmoud.github.io/adapttable/url-state/">url-state</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or

--- a/apps/showcase/radix/scale/index.html
+++ b/apps/showcase/radix/scale/index.html
@@ -165,6 +165,36 @@ export function Ledger({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/scale/">Large datasets in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/scale/">Large datasets in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/scale/">Large datasets in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/scale/">Large datasets in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../base-ui/scale/">Large datasets in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/scale/">Large datasets in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/scale/">Large datasets in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Radix features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Radix</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Radix</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Radix</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Radix</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Radix</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Radix</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Radix</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Radix</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Radix</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../tree/">Tree data in Radix</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Radix</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Radix</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Radix</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Radix</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Radix data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Radix</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Radix data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or

--- a/apps/showcase/radix/scale/index.html
+++ b/apps/showcase/radix/scale/index.html
@@ -166,7 +166,7 @@ export function Ledger({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/performance/">performance</a>, <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/radix/selection/index.html
+++ b/apps/showcase/radix/selection/index.html
@@ -170,7 +170,7 @@ export function People({ rows, columns, onArchive }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>, <a href="https://orwa-mahmoud.github.io/adapttable/bulk-actions/">bulk-actions</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/radix/selection/index.html
+++ b/apps/showcase/radix/selection/index.html
@@ -169,6 +169,36 @@ export function People({ rows, columns, onArchive }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/selection/">Row selection in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/selection/">Row selection in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/selection/">Row selection in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/selection/">Row selection in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../base-ui/selection/">Row selection in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/selection/">Row selection in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/selection/">Row selection in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Radix features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Radix</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Radix</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Radix</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../rows/">Rows in Radix</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Radix</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Radix</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Radix</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Radix</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Radix</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Radix</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Radix</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Radix</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Radix</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Radix</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Radix data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Radix</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Radix data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or

--- a/apps/showcase/radix/tree/index.html
+++ b/apps/showcase/radix/tree/index.html
@@ -164,6 +164,36 @@ export function Org({ people, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/radix @adapttable/core @radix-ui/themes</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/tree/">Tree data in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/tree/">Tree data in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/tree/">Tree data in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/tree/">Tree data in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../base-ui/tree/">Tree data in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/tree/">Tree data in shadcn</a> — Monochrome, ring focus</li>
+          <li><a href="../../tailwind/tree/">Tree data in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More Radix features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Radix</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Radix</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Radix</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Radix</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Radix</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Radix</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Radix</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Radix</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Radix</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Radix</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Radix</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Radix</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Radix</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Radix</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Radix data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Radix</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Radix data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/tree-data/">tree-data</a>. More of this kit:
           <a href="../">AdaptTable for Radix</a>, or

--- a/apps/showcase/shadcn/accessibility/index.html
+++ b/apps/showcase/shadcn/accessibility/index.html
@@ -163,6 +163,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/accessibility/">Accessible Mantine data table</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/accessibility/">Accessible MUI data table</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/accessibility/">Accessible Chakra data table</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/accessibility/">Accessible Ant Design data table</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/accessibility/">Accessible Radix data table</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/accessibility/">Accessible Base UI data table</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../tailwind/accessibility/">Accessible Tailwind data table</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More shadcn features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in shadcn</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in shadcn</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in shadcn</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in shadcn</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in shadcn</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in shadcn</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in shadcn</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in shadcn</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in shadcn</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in shadcn</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in shadcn</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in shadcn</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in shadcn</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in shadcn</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in shadcn</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left shadcn data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in shadcn</a> — Rows change while you read them. Sort and selection hold.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/accessibility/">accessibility</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or

--- a/apps/showcase/shadcn/column-groups/index.html
+++ b/apps/showcase/shadcn/column-groups/index.html
@@ -189,6 +189,36 @@ export function People({ rows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/column-groups/">Column groups in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/column-groups/">Column groups in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/column-groups/">Column groups in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/column-groups/">Column groups in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/column-groups/">Column groups in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/column-groups/">Column groups in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../tailwind/column-groups/">Column groups in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More shadcn features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in shadcn</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in shadcn</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../selection/">Row selection in shadcn</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in shadcn</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in shadcn</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in shadcn</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in shadcn</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in shadcn</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in shadcn</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in shadcn</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in shadcn</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in shadcn</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in shadcn</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in shadcn</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left shadcn data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in shadcn</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible shadcn data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/column-groups/">column-groups</a>, <a href="https://orwa-mahmoud.github.io/adapttable/columns/">columns</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or

--- a/apps/showcase/shadcn/columns/index.html
+++ b/apps/showcase/shadcn/columns/index.html
@@ -165,6 +165,36 @@ export function People({ rows, columns, layout, onLayout }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/columns/">Column management in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/columns/">Column management in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/columns/">Column management in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/columns/">Column management in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/columns/">Column management in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/columns/">Column management in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../tailwind/columns/">Column management in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More shadcn features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in shadcn</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../column-groups/">Column groups in shadcn</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in shadcn</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in shadcn</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in shadcn</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in shadcn</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in shadcn</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in shadcn</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in shadcn</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in shadcn</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in shadcn</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in shadcn</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in shadcn</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in shadcn</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left shadcn data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in shadcn</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible shadcn data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/column-management/">column-management</a>, <a href="https://orwa-mahmoud.github.io/adapttable/columns/">columns</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or

--- a/apps/showcase/shadcn/editing/index.html
+++ b/apps/showcase/shadcn/editing/index.html
@@ -176,6 +176,36 @@ export function People({ rows, onSave }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/editing/">Inline cell editing in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/editing/">Inline cell editing in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/editing/">Inline cell editing in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/editing/">Inline cell editing in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/editing/">Inline cell editing in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/editing/">Inline cell editing in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../tailwind/editing/">Inline cell editing in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More shadcn features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in shadcn</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in shadcn</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in shadcn</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in shadcn</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in shadcn</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../grouping/">Row grouping in shadcn</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in shadcn</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in shadcn</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in shadcn</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in shadcn</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in shadcn</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in shadcn</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in shadcn</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in shadcn</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left shadcn data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in shadcn</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible shadcn data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or

--- a/apps/showcase/shadcn/editing/index.html
+++ b/apps/showcase/shadcn/editing/index.html
@@ -177,7 +177,7 @@ export function People({ rows, onSave }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/editing/">editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/shadcn/export/index.html
+++ b/apps/showcase/shadcn/export/index.html
@@ -169,7 +169,7 @@ export function People({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-csv/">export-csv</a>, <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/shadcn/export/index.html
+++ b/apps/showcase/shadcn/export/index.html
@@ -168,6 +168,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/export/">Export and print in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/export/">Export and print in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/export/">Export and print in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/export/">Export and print in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/export/">Export and print in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/export/">Export and print in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../tailwind/export/">Export and print in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More shadcn features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in shadcn</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in shadcn</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in shadcn</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in shadcn</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in shadcn</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in shadcn</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in shadcn</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in shadcn</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../scale/">Large datasets in shadcn</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in shadcn</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in shadcn</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in shadcn</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in shadcn</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in shadcn</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left shadcn data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in shadcn</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible shadcn data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or

--- a/apps/showcase/shadcn/filtering/index.html
+++ b/apps/showcase/shadcn/filtering/index.html
@@ -173,6 +173,36 @@ export function People({ rows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/filtering/">Filtering in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/filtering/">Filtering in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/filtering/">Filtering in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/filtering/">Filtering in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/filtering/">Filtering in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/filtering/">Filtering in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../tailwind/filtering/">Filtering in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More shadcn features</h2>
+        <ul>
+          <li><a href="../columns/">Column management in shadcn</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in shadcn</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in shadcn</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in shadcn</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in shadcn</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in shadcn</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in shadcn</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in shadcn</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in shadcn</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in shadcn</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in shadcn</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in shadcn</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in shadcn</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in shadcn</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left shadcn data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in shadcn</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible shadcn data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/filtering/">filtering</a>, <a href="https://orwa-mahmoud.github.io/adapttable/filter-tree/">filter-tree</a>, <a href="https://orwa-mahmoud.github.io/adapttable/url-state/">url-state</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or

--- a/apps/showcase/shadcn/formulas/index.html
+++ b/apps/showcase/shadcn/formulas/index.html
@@ -175,6 +175,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/formulas/">Spreadsheet formulas in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/formulas/">Spreadsheet formulas in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/formulas/">Spreadsheet formulas in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/formulas/">Spreadsheet formulas in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/formulas/">Spreadsheet formulas in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/formulas/">Spreadsheet formulas in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../tailwind/formulas/">Spreadsheet formulas in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More shadcn features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in shadcn</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in shadcn</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in shadcn</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in shadcn</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in shadcn</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in shadcn</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in shadcn</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in shadcn</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in shadcn</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in shadcn</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in shadcn</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in shadcn</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in shadcn</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in shadcn</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../rtl/">Right-to-left shadcn data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in shadcn</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible shadcn data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/formulas/">formulas</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or

--- a/apps/showcase/shadcn/grouping/index.html
+++ b/apps/showcase/shadcn/grouping/index.html
@@ -169,6 +169,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/grouping/">Row grouping in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/grouping/">Row grouping in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/grouping/">Row grouping in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/grouping/">Row grouping in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/grouping/">Row grouping in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/grouping/">Row grouping in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../tailwind/grouping/">Row grouping in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More shadcn features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in shadcn</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in shadcn</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in shadcn</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in shadcn</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in shadcn</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in shadcn</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../nested-tables/">Nested tables in shadcn</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in shadcn</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in shadcn</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in shadcn</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in shadcn</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in shadcn</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in shadcn</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in shadcn</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left shadcn data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in shadcn</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible shadcn data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-grouping/">row-grouping</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or

--- a/apps/showcase/shadcn/grouping/index.html
+++ b/apps/showcase/shadcn/grouping/index.html
@@ -170,7 +170,7 @@ export function People({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/grouping/">grouping</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-grouping/">row-grouping</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/shadcn/index.html
+++ b/apps/showcase/shadcn/index.html
@@ -169,6 +169,17 @@
           <li><a href="./realtime/">Live updates in shadcn</a> — Rows change while you read them. Sort and selection hold.</li>
           <li><a href="./accessibility/">Accessible shadcn data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
         </ul>
+        <h2>The same table, in seven other kits</h2>
+        <p>Switching kit changes the components, never the model — the props on this page are the props there.</p>
+        <ul>
+          <li><a href="../mantine/">AdaptTable for Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../mui/">AdaptTable for MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../chakra/">AdaptTable for Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../antd/">AdaptTable for Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../radix/">AdaptTable for Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../base-ui/">AdaptTable for Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../tailwind/">AdaptTable for Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/getting-started/">getting started</a>. Or
           open <a href="/adapttable/demo/">the live demo</a> and switch kits on

--- a/apps/showcase/shadcn/mobile-cards/index.html
+++ b/apps/showcase/shadcn/mobile-cards/index.html
@@ -166,6 +166,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/mobile-cards/">Mobile cards in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/mobile-cards/">Mobile cards in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/mobile-cards/">Mobile cards in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/mobile-cards/">Mobile cards in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/mobile-cards/">Mobile cards in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/mobile-cards/">Mobile cards in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../tailwind/mobile-cards/">Mobile cards in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More shadcn features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in shadcn</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in shadcn</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in shadcn</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in shadcn</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in shadcn</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in shadcn</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in shadcn</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in shadcn</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in shadcn</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in shadcn</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in shadcn</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../pivot/">Pivot tables in shadcn</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in shadcn</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in shadcn</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left shadcn data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in shadcn</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible shadcn data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/mobile/">mobile</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or

--- a/apps/showcase/shadcn/nested-tables/index.html
+++ b/apps/showcase/shadcn/nested-tables/index.html
@@ -172,6 +172,36 @@ export function People({ rows, columns, orderColumns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/nested-tables/">Nested tables in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/nested-tables/">Nested tables in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/nested-tables/">Nested tables in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/nested-tables/">Nested tables in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/nested-tables/">Nested tables in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/nested-tables/">Nested tables in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../tailwind/nested-tables/">Nested tables in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More shadcn features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in shadcn</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in shadcn</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in shadcn</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in shadcn</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in shadcn</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in shadcn</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in shadcn</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../export/">Export and print in shadcn</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in shadcn</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in shadcn</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in shadcn</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in shadcn</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in shadcn</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in shadcn</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left shadcn data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in shadcn</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible shadcn data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/tree-data/">tree-data</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-expansion/">row-expansion</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or

--- a/apps/showcase/shadcn/pivot/index.html
+++ b/apps/showcase/shadcn/pivot/index.html
@@ -173,6 +173,36 @@ export function Spend({ rows, fields }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/pivot/">Pivot tables in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/pivot/">Pivot tables in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/pivot/">Pivot tables in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/pivot/">Pivot tables in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/pivot/">Pivot tables in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/pivot/">Pivot tables in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../tailwind/pivot/">Pivot tables in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More shadcn features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in shadcn</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in shadcn</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in shadcn</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in shadcn</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in shadcn</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in shadcn</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in shadcn</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in shadcn</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in shadcn</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in shadcn</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in shadcn</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in shadcn</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../saved-views/">Saved views in shadcn</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in shadcn</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left shadcn data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in shadcn</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible shadcn data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/pivot/">pivot</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or

--- a/apps/showcase/shadcn/realtime/index.html
+++ b/apps/showcase/shadcn/realtime/index.html
@@ -170,6 +170,36 @@ export function People({ rows, columns, setRows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/realtime/">Live updates in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/realtime/">Live updates in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/realtime/">Live updates in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/realtime/">Live updates in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/realtime/">Live updates in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/realtime/">Live updates in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../tailwind/realtime/">Live updates in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More shadcn features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in shadcn</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in shadcn</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in shadcn</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in shadcn</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in shadcn</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in shadcn</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in shadcn</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in shadcn</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in shadcn</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in shadcn</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in shadcn</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in shadcn</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in shadcn</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in shadcn</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in shadcn</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left shadcn data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../accessibility/">Accessible shadcn data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/realtime/">realtime</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or

--- a/apps/showcase/shadcn/rows/index.html
+++ b/apps/showcase/shadcn/rows/index.html
@@ -165,6 +165,36 @@ export function People({ rows, columns, onReorder, setPinned, spanTeam }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/rows/">Rows in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/rows/">Rows in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/rows/">Rows in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/rows/">Rows in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/rows/">Rows in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/rows/">Rows in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../tailwind/rows/">Rows in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More shadcn features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in shadcn</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in shadcn</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in shadcn</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in shadcn</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../editing/">Inline cell editing in shadcn</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in shadcn</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in shadcn</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in shadcn</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in shadcn</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in shadcn</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in shadcn</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in shadcn</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in shadcn</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in shadcn</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left shadcn data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in shadcn</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible shadcn data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-pinning/">row-pinning</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-reordering/">row-reordering</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-spanning/">row-spanning</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or

--- a/apps/showcase/shadcn/rtl/index.html
+++ b/apps/showcase/shadcn/rtl/index.html
@@ -163,6 +163,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/rtl/">Right-to-left Mantine data table</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/rtl/">Right-to-left MUI data table</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/rtl/">Right-to-left Chakra data table</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/rtl/">Right-to-left Ant Design data table</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/rtl/">Right-to-left Radix data table</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/rtl/">Right-to-left Base UI data table</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../tailwind/rtl/">Right-to-left Tailwind data table</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More shadcn features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in shadcn</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in shadcn</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in shadcn</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in shadcn</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in shadcn</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in shadcn</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in shadcn</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in shadcn</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in shadcn</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in shadcn</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in shadcn</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in shadcn</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in shadcn</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in shadcn</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in shadcn</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../realtime/">Live updates in shadcn</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible shadcn data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/i18n-rtl/">i18n-rtl</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or

--- a/apps/showcase/shadcn/saved-views/index.html
+++ b/apps/showcase/shadcn/saved-views/index.html
@@ -181,6 +181,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/saved-views/">Saved views in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/saved-views/">Saved views in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/saved-views/">Saved views in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/saved-views/">Saved views in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/saved-views/">Saved views in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/saved-views/">Saved views in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../tailwind/saved-views/">Saved views in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More shadcn features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in shadcn</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in shadcn</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in shadcn</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in shadcn</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in shadcn</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in shadcn</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in shadcn</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in shadcn</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in shadcn</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in shadcn</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in shadcn</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in shadcn</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in shadcn</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in shadcn</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left shadcn data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in shadcn</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible shadcn data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/saved-views/">saved-views</a>, <a href="https://orwa-mahmoud.github.io/adapttable/url-state/">url-state</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or

--- a/apps/showcase/shadcn/scale/index.html
+++ b/apps/showcase/shadcn/scale/index.html
@@ -165,6 +165,36 @@ export function Ledger({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/scale/">Large datasets in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/scale/">Large datasets in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/scale/">Large datasets in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/scale/">Large datasets in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/scale/">Large datasets in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/scale/">Large datasets in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../tailwind/scale/">Large datasets in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More shadcn features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in shadcn</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in shadcn</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in shadcn</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in shadcn</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in shadcn</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in shadcn</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in shadcn</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in shadcn</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in shadcn</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../tree/">Tree data in shadcn</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in shadcn</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in shadcn</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in shadcn</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in shadcn</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left shadcn data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in shadcn</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible shadcn data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or

--- a/apps/showcase/shadcn/scale/index.html
+++ b/apps/showcase/shadcn/scale/index.html
@@ -166,7 +166,7 @@ export function Ledger({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/performance/">performance</a>, <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/shadcn/selection/index.html
+++ b/apps/showcase/shadcn/selection/index.html
@@ -170,7 +170,7 @@ export function People({ rows, columns, onArchive }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>, <a href="https://orwa-mahmoud.github.io/adapttable/bulk-actions/">bulk-actions</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/shadcn/selection/index.html
+++ b/apps/showcase/shadcn/selection/index.html
@@ -169,6 +169,36 @@ export function People({ rows, columns, onArchive }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/selection/">Row selection in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/selection/">Row selection in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/selection/">Row selection in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/selection/">Row selection in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/selection/">Row selection in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/selection/">Row selection in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../tailwind/selection/">Row selection in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More shadcn features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in shadcn</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in shadcn</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in shadcn</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../rows/">Rows in shadcn</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in shadcn</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in shadcn</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in shadcn</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in shadcn</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in shadcn</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in shadcn</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in shadcn</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in shadcn</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in shadcn</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in shadcn</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left shadcn data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in shadcn</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible shadcn data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or

--- a/apps/showcase/shadcn/tree/index.html
+++ b/apps/showcase/shadcn/tree/index.html
@@ -164,6 +164,36 @@ export function Org({ people, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/shadcn @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/tree/">Tree data in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/tree/">Tree data in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/tree/">Tree data in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/tree/">Tree data in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/tree/">Tree data in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/tree/">Tree data in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../tailwind/tree/">Tree data in Tailwind</a> — Unstyled — your own classes</li>
+        </ul>
+        <h2>More shadcn features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in shadcn</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in shadcn</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in shadcn</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in shadcn</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in shadcn</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in shadcn</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in shadcn</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in shadcn</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in shadcn</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in shadcn</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../mobile-cards/">Mobile cards in shadcn</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in shadcn</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in shadcn</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in shadcn</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left shadcn data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in shadcn</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible shadcn data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/tree-data/">tree-data</a>. More of this kit:
           <a href="../">AdaptTable for shadcn</a>, or

--- a/apps/showcase/tailwind/accessibility/index.html
+++ b/apps/showcase/tailwind/accessibility/index.html
@@ -163,6 +163,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/accessibility/">Accessible Mantine data table</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/accessibility/">Accessible MUI data table</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/accessibility/">Accessible Chakra data table</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/accessibility/">Accessible Ant Design data table</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/accessibility/">Accessible Radix data table</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/accessibility/">Accessible Base UI data table</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/accessibility/">Accessible shadcn data table</a> — Monochrome, ring focus</li>
+        </ul>
+        <h2>More Tailwind features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Tailwind</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Tailwind</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Tailwind</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Tailwind</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Tailwind</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Tailwind</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Tailwind</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Tailwind</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Tailwind</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Tailwind</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Tailwind</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Tailwind</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Tailwind</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Tailwind</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Tailwind</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Tailwind data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Tailwind</a> — Rows change while you read them. Sort and selection hold.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/accessibility/">accessibility</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or

--- a/apps/showcase/tailwind/column-groups/index.html
+++ b/apps/showcase/tailwind/column-groups/index.html
@@ -189,6 +189,36 @@ export function People({ rows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/column-groups/">Column groups in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/column-groups/">Column groups in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/column-groups/">Column groups in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/column-groups/">Column groups in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/column-groups/">Column groups in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/column-groups/">Column groups in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/column-groups/">Column groups in shadcn</a> — Monochrome, ring focus</li>
+        </ul>
+        <h2>More Tailwind features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Tailwind</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Tailwind</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../selection/">Row selection in Tailwind</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Tailwind</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Tailwind</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Tailwind</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Tailwind</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Tailwind</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Tailwind</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Tailwind</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Tailwind</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Tailwind</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Tailwind</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Tailwind</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Tailwind data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Tailwind</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Tailwind data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/column-groups/">column-groups</a>, <a href="https://orwa-mahmoud.github.io/adapttable/columns/">columns</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or

--- a/apps/showcase/tailwind/columns/index.html
+++ b/apps/showcase/tailwind/columns/index.html
@@ -165,6 +165,36 @@ export function People({ rows, columns, layout, onLayout }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/columns/">Column management in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/columns/">Column management in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/columns/">Column management in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/columns/">Column management in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/columns/">Column management in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/columns/">Column management in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/columns/">Column management in shadcn</a> — Monochrome, ring focus</li>
+        </ul>
+        <h2>More Tailwind features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Tailwind</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../column-groups/">Column groups in Tailwind</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Tailwind</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Tailwind</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Tailwind</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Tailwind</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Tailwind</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Tailwind</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Tailwind</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Tailwind</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Tailwind</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Tailwind</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Tailwind</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Tailwind</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Tailwind data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Tailwind</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Tailwind data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/column-management/">column-management</a>, <a href="https://orwa-mahmoud.github.io/adapttable/columns/">columns</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or

--- a/apps/showcase/tailwind/editing/index.html
+++ b/apps/showcase/tailwind/editing/index.html
@@ -176,6 +176,36 @@ export function People({ rows, onSave }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/editing/">Inline cell editing in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/editing/">Inline cell editing in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/editing/">Inline cell editing in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/editing/">Inline cell editing in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/editing/">Inline cell editing in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/editing/">Inline cell editing in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/editing/">Inline cell editing in shadcn</a> — Monochrome, ring focus</li>
+        </ul>
+        <h2>More Tailwind features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Tailwind</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Tailwind</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Tailwind</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Tailwind</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Tailwind</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../grouping/">Row grouping in Tailwind</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Tailwind</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Tailwind</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Tailwind</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Tailwind</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Tailwind</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Tailwind</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Tailwind</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Tailwind</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Tailwind data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Tailwind</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Tailwind data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or

--- a/apps/showcase/tailwind/editing/index.html
+++ b/apps/showcase/tailwind/editing/index.html
@@ -177,7 +177,7 @@ export function People({ rows, onSave }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/editing/">editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-navigation/">cell-navigation</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/tailwind/export/index.html
+++ b/apps/showcase/tailwind/export/index.html
@@ -169,7 +169,7 @@ export function People({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-csv/">export-csv</a>, <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/tailwind/export/index.html
+++ b/apps/showcase/tailwind/export/index.html
@@ -168,6 +168,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/export/">Export and print in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/export/">Export and print in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/export/">Export and print in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/export/">Export and print in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/export/">Export and print in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/export/">Export and print in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/export/">Export and print in shadcn</a> — Monochrome, ring focus</li>
+        </ul>
+        <h2>More Tailwind features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Tailwind</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Tailwind</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Tailwind</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Tailwind</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Tailwind</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Tailwind</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Tailwind</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Tailwind</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../scale/">Large datasets in Tailwind</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Tailwind</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Tailwind</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Tailwind</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Tailwind</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Tailwind</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Tailwind data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Tailwind</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Tailwind data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/export-pdf/">export-pdf</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or

--- a/apps/showcase/tailwind/filtering/index.html
+++ b/apps/showcase/tailwind/filtering/index.html
@@ -173,6 +173,36 @@ export function People({ rows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/filtering/">Filtering in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/filtering/">Filtering in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/filtering/">Filtering in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/filtering/">Filtering in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/filtering/">Filtering in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/filtering/">Filtering in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/filtering/">Filtering in shadcn</a> — Monochrome, ring focus</li>
+        </ul>
+        <h2>More Tailwind features</h2>
+        <ul>
+          <li><a href="../columns/">Column management in Tailwind</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Tailwind</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Tailwind</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Tailwind</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Tailwind</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Tailwind</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Tailwind</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Tailwind</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Tailwind</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Tailwind</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Tailwind</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Tailwind</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Tailwind</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Tailwind</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Tailwind data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Tailwind</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Tailwind data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/filtering/">filtering</a>, <a href="https://orwa-mahmoud.github.io/adapttable/filter-tree/">filter-tree</a>, <a href="https://orwa-mahmoud.github.io/adapttable/url-state/">url-state</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or

--- a/apps/showcase/tailwind/formulas/index.html
+++ b/apps/showcase/tailwind/formulas/index.html
@@ -175,6 +175,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/formulas/">Spreadsheet formulas in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/formulas/">Spreadsheet formulas in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/formulas/">Spreadsheet formulas in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/formulas/">Spreadsheet formulas in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/formulas/">Spreadsheet formulas in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/formulas/">Spreadsheet formulas in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/formulas/">Spreadsheet formulas in shadcn</a> — Monochrome, ring focus</li>
+        </ul>
+        <h2>More Tailwind features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Tailwind</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Tailwind</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Tailwind</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Tailwind</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Tailwind</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Tailwind</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Tailwind</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Tailwind</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Tailwind</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Tailwind</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Tailwind</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Tailwind</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Tailwind</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Tailwind</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../rtl/">Right-to-left Tailwind data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Tailwind</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Tailwind data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/formulas/">formulas</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or

--- a/apps/showcase/tailwind/grouping/index.html
+++ b/apps/showcase/tailwind/grouping/index.html
@@ -169,6 +169,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/grouping/">Row grouping in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/grouping/">Row grouping in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/grouping/">Row grouping in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/grouping/">Row grouping in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/grouping/">Row grouping in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/grouping/">Row grouping in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/grouping/">Row grouping in shadcn</a> — Monochrome, ring focus</li>
+        </ul>
+        <h2>More Tailwind features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Tailwind</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Tailwind</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Tailwind</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Tailwind</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Tailwind</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Tailwind</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../nested-tables/">Nested tables in Tailwind</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Tailwind</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Tailwind</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Tailwind</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Tailwind</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Tailwind</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Tailwind</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Tailwind</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Tailwind data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Tailwind</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Tailwind data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-grouping/">row-grouping</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or

--- a/apps/showcase/tailwind/grouping/index.html
+++ b/apps/showcase/tailwind/grouping/index.html
@@ -170,7 +170,7 @@ export function People({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/grouping/">grouping</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-grouping/">row-grouping</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/tailwind/index.html
+++ b/apps/showcase/tailwind/index.html
@@ -169,6 +169,17 @@
           <li><a href="./realtime/">Live updates in Tailwind</a> — Rows change while you read them. Sort and selection hold.</li>
           <li><a href="./accessibility/">Accessible Tailwind data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
         </ul>
+        <h2>The same table, in seven other kits</h2>
+        <p>Switching kit changes the components, never the model — the props on this page are the props there.</p>
+        <ul>
+          <li><a href="../mantine/">AdaptTable for Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../mui/">AdaptTable for MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../chakra/">AdaptTable for Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../antd/">AdaptTable for Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../radix/">AdaptTable for Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../base-ui/">AdaptTable for Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../shadcn/">AdaptTable for shadcn</a> — Monochrome, ring focus</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/getting-started/">getting started</a>. Or
           open <a href="/adapttable/demo/">the live demo</a> and switch kits on

--- a/apps/showcase/tailwind/mobile-cards/index.html
+++ b/apps/showcase/tailwind/mobile-cards/index.html
@@ -166,6 +166,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/mobile-cards/">Mobile cards in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/mobile-cards/">Mobile cards in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/mobile-cards/">Mobile cards in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/mobile-cards/">Mobile cards in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/mobile-cards/">Mobile cards in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/mobile-cards/">Mobile cards in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/mobile-cards/">Mobile cards in shadcn</a> — Monochrome, ring focus</li>
+        </ul>
+        <h2>More Tailwind features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Tailwind</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Tailwind</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Tailwind</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Tailwind</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Tailwind</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Tailwind</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Tailwind</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Tailwind</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Tailwind</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Tailwind</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Tailwind</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../pivot/">Pivot tables in Tailwind</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Tailwind</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Tailwind</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Tailwind data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Tailwind</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Tailwind data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/mobile/">mobile</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or

--- a/apps/showcase/tailwind/nested-tables/index.html
+++ b/apps/showcase/tailwind/nested-tables/index.html
@@ -172,6 +172,36 @@ export function People({ rows, columns, orderColumns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/nested-tables/">Nested tables in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/nested-tables/">Nested tables in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/nested-tables/">Nested tables in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/nested-tables/">Nested tables in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/nested-tables/">Nested tables in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/nested-tables/">Nested tables in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/nested-tables/">Nested tables in shadcn</a> — Monochrome, ring focus</li>
+        </ul>
+        <h2>More Tailwind features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Tailwind</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Tailwind</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Tailwind</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Tailwind</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Tailwind</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Tailwind</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Tailwind</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../export/">Export and print in Tailwind</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Tailwind</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Tailwind</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Tailwind</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Tailwind</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Tailwind</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Tailwind</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Tailwind data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Tailwind</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Tailwind data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/tree-data/">tree-data</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-expansion/">row-expansion</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or

--- a/apps/showcase/tailwind/pivot/index.html
+++ b/apps/showcase/tailwind/pivot/index.html
@@ -173,6 +173,36 @@ export function Spend({ rows, fields }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/pivot/">Pivot tables in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/pivot/">Pivot tables in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/pivot/">Pivot tables in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/pivot/">Pivot tables in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/pivot/">Pivot tables in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/pivot/">Pivot tables in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/pivot/">Pivot tables in shadcn</a> — Monochrome, ring focus</li>
+        </ul>
+        <h2>More Tailwind features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Tailwind</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Tailwind</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Tailwind</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Tailwind</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Tailwind</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Tailwind</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Tailwind</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Tailwind</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Tailwind</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Tailwind</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Tailwind</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Tailwind</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../saved-views/">Saved views in Tailwind</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Tailwind</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Tailwind data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Tailwind</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Tailwind data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/pivot/">pivot</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or

--- a/apps/showcase/tailwind/realtime/index.html
+++ b/apps/showcase/tailwind/realtime/index.html
@@ -170,6 +170,36 @@ export function People({ rows, columns, setRows }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/realtime/">Live updates in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/realtime/">Live updates in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/realtime/">Live updates in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/realtime/">Live updates in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/realtime/">Live updates in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/realtime/">Live updates in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/realtime/">Live updates in shadcn</a> — Monochrome, ring focus</li>
+        </ul>
+        <h2>More Tailwind features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Tailwind</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Tailwind</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Tailwind</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Tailwind</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Tailwind</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Tailwind</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Tailwind</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Tailwind</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Tailwind</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Tailwind</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Tailwind</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Tailwind</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Tailwind</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Tailwind</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Tailwind</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Tailwind data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../accessibility/">Accessible Tailwind data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/realtime/">realtime</a>, <a href="https://orwa-mahmoud.github.io/adapttable/cell-editing/">cell-editing</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or

--- a/apps/showcase/tailwind/rows/index.html
+++ b/apps/showcase/tailwind/rows/index.html
@@ -165,6 +165,36 @@ export function People({ rows, columns, onReorder, setPinned, spanTeam }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/rows/">Rows in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/rows/">Rows in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/rows/">Rows in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/rows/">Rows in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/rows/">Rows in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/rows/">Rows in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/rows/">Rows in shadcn</a> — Monochrome, ring focus</li>
+        </ul>
+        <h2>More Tailwind features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Tailwind</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Tailwind</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Tailwind</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Tailwind</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../editing/">Inline cell editing in Tailwind</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Tailwind</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Tailwind</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Tailwind</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Tailwind</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Tailwind</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Tailwind</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Tailwind</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Tailwind</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Tailwind</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Tailwind data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Tailwind</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Tailwind data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/row-pinning/">row-pinning</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-reordering/">row-reordering</a>, <a href="https://orwa-mahmoud.github.io/adapttable/row-spanning/">row-spanning</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or

--- a/apps/showcase/tailwind/rtl/index.html
+++ b/apps/showcase/tailwind/rtl/index.html
@@ -163,6 +163,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/rtl/">Right-to-left Mantine data table</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/rtl/">Right-to-left MUI data table</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/rtl/">Right-to-left Chakra data table</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/rtl/">Right-to-left Ant Design data table</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/rtl/">Right-to-left Radix data table</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/rtl/">Right-to-left Base UI data table</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/rtl/">Right-to-left shadcn data table</a> — Monochrome, ring focus</li>
+        </ul>
+        <h2>More Tailwind features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Tailwind</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Tailwind</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Tailwind</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Tailwind</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Tailwind</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Tailwind</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Tailwind</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Tailwind</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Tailwind</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Tailwind</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Tailwind</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Tailwind</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Tailwind</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Tailwind</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Tailwind</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../realtime/">Live updates in Tailwind</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Tailwind data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/i18n-rtl/">i18n-rtl</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or

--- a/apps/showcase/tailwind/saved-views/index.html
+++ b/apps/showcase/tailwind/saved-views/index.html
@@ -181,6 +181,36 @@ export function People({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/saved-views/">Saved views in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/saved-views/">Saved views in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/saved-views/">Saved views in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/saved-views/">Saved views in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/saved-views/">Saved views in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/saved-views/">Saved views in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/saved-views/">Saved views in shadcn</a> — Monochrome, ring focus</li>
+        </ul>
+        <h2>More Tailwind features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Tailwind</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Tailwind</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Tailwind</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Tailwind</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Tailwind</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Tailwind</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Tailwind</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Tailwind</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Tailwind</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Tailwind</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Tailwind</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Tailwind</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Tailwind</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Tailwind</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Tailwind data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Tailwind</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Tailwind data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/saved-views/">saved-views</a>, <a href="https://orwa-mahmoud.github.io/adapttable/url-state/">url-state</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or

--- a/apps/showcase/tailwind/scale/index.html
+++ b/apps/showcase/tailwind/scale/index.html
@@ -166,7 +166,7 @@ export function Ledger({ rows, columns }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/performance/">performance</a>, <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/tailwind/scale/index.html
+++ b/apps/showcase/tailwind/scale/index.html
@@ -165,6 +165,36 @@ export function Ledger({ rows, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/scale/">Large datasets in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/scale/">Large datasets in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/scale/">Large datasets in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/scale/">Large datasets in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/scale/">Large datasets in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/scale/">Large datasets in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/scale/">Large datasets in shadcn</a> — Monochrome, ring focus</li>
+        </ul>
+        <h2>More Tailwind features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Tailwind</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Tailwind</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Tailwind</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Tailwind</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Tailwind</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Tailwind</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Tailwind</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Tailwind</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Tailwind</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../tree/">Tree data in Tailwind</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Tailwind</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Tailwind</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Tailwind</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Tailwind</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Tailwind data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Tailwind</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Tailwind data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/virtualization/">virtualization</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or

--- a/apps/showcase/tailwind/selection/index.html
+++ b/apps/showcase/tailwind/selection/index.html
@@ -170,7 +170,7 @@ export function People({ rows, columns, onArchive }) {
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
         <p>
-          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>, <a href="https://orwa-mahmoud.github.io/adapttable/bulk-actions/">bulk-actions</a>. More of this kit:
+          Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or
           <a href="/adapttable/demo/">the live demo</a>.
         </p>

--- a/apps/showcase/tailwind/selection/index.html
+++ b/apps/showcase/tailwind/selection/index.html
@@ -169,6 +169,36 @@ export function People({ rows, columns, onArchive }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/selection/">Row selection in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/selection/">Row selection in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/selection/">Row selection in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/selection/">Row selection in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/selection/">Row selection in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/selection/">Row selection in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/selection/">Row selection in shadcn</a> — Monochrome, ring focus</li>
+        </ul>
+        <h2>More Tailwind features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Tailwind</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Tailwind</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Tailwind</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../rows/">Rows in Tailwind</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Tailwind</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Tailwind</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Tailwind</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Tailwind</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Tailwind</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../tree/">Tree data in Tailwind</a> — Rows that contain rows — nesting, chevrons, keyboard traversal.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Tailwind</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Tailwind</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Tailwind</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Tailwind</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Tailwind data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Tailwind</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Tailwind data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/selection/">selection</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or

--- a/apps/showcase/tailwind/tree/index.html
+++ b/apps/showcase/tailwind/tree/index.html
@@ -164,6 +164,36 @@ export function Org({ people, columns }) {
 }</code></pre>
         <h2>Install</h2>
         <pre><code>pnpm add @adapttable/unstyled @adapttable/core</code></pre>
+        <h2>The same feature in the other kits</h2>
+        <ul>
+          <li><a href="../../mantine/tree/">Tree data in Mantine</a> — Rounded, friendly, filled controls</li>
+          <li><a href="../../mui/tree/">Tree data in MUI</a> — Material elevation, uppercase actions</li>
+          <li><a href="../../chakra/tree/">Tree data in Chakra</a> — Soft teal, generous radius</li>
+          <li><a href="../../antd/tree/">Tree data in Ant Design</a> — Compact, tinted header, crisp</li>
+          <li><a href="../../radix/tree/">Tree data in Radix</a> — Radix Themes, iris accent</li>
+          <li><a href="../../base-ui/tree/">Tree data in Base UI</a> — Unstyled primitives, blue accent</li>
+          <li><a href="../../shadcn/tree/">Tree data in shadcn</a> — Monochrome, ring focus</li>
+        </ul>
+        <h2>More Tailwind features</h2>
+        <ul>
+          <li><a href="../filtering/">Filtering in Tailwind</a> — Kit-native operators, date ranges, checklists, an AND/OR tree, chips.</li>
+          <li><a href="../columns/">Column management in Tailwind</a> — Show, hide, reorder, pin and resize — from a menu you did not write.</li>
+          <li><a href="../column-groups/">Column groups in Tailwind</a> — Spanning headers that collapse to a stub, a kept child, or a custom cell.</li>
+          <li><a href="../selection/">Row selection in Tailwind</a> — A set of ids that survives paging, with bulk actions over it.</li>
+          <li><a href="../rows/">Rows in Tailwind</a> — Pin, drag-reorder, merge cells, and a 3-dot menu per row.</li>
+          <li><a href="../editing/">Inline cell editing in Tailwind</a> — Kit-native editors in the cell; every write goes through your handler.</li>
+          <li><a href="../grouping/">Row grouping in Tailwind</a> — Nested group headers with counts, subtotals, footers and collapse state.</li>
+          <li><a href="../nested-tables/">Nested tables in Tailwind</a> — A real table under a row — same engine, own columns, own keys.</li>
+          <li><a href="../export/">Export and print in Tailwind</a> — CSV, XLSX and PDF from one seam — plus a real print layout.</li>
+          <li><a href="../scale/">Large datasets in Tailwind</a> — 100k rows, 40 columns, virtualized rows and columns, sticky chrome.</li>
+          <li><a href="../mobile-cards/">Mobile cards in Tailwind</a> — Every row becomes a card on phones. Automatically, with the same state.</li>
+          <li><a href="../pivot/">Pivot tables in Tailwind</a> — Rows down the side, dimensions across the top, subtotals at every level.</li>
+          <li><a href="../saved-views/">Saved views in Tailwind</a> — Name an arrangement, share it as a link, manage the list in place.</li>
+          <li><a href="../formulas/">Spreadsheet formulas in Tailwind</a> — Computed columns typed as formulas, errors reported in the cell.</li>
+          <li><a href="../rtl/">Right-to-left Tailwind data table</a> — Arabic strings, a flipped axis, and a popover that opens from the right edge.</li>
+          <li><a href="../realtime/">Live updates in Tailwind</a> — Rows change while you read them. Sort and selection hold.</li>
+          <li><a href="../accessibility/">Accessible Tailwind data table</a> — Arrow-key focus, a visible ring, and every announcement shown as text.</li>
+        </ul>
         <p>
           Reference: <a href="https://orwa-mahmoud.github.io/adapttable/tree-data/">tree-data</a>. More of this kit:
           <a href="../">AdaptTable for Tailwind</a>, or

--- a/scripts/build-showcase-html.mjs
+++ b/scripts/build-showcase-html.mjs
@@ -26,6 +26,7 @@ import { fileURLToPath } from "node:url";
 
 import {
   adapterByKey,
+  builtAdapters,
   featureBySlug,
   fillTemplate,
   introFor,
@@ -244,6 +245,37 @@ const docsList = (slugs) =>
   slugs.map((slug) => `<a href="${DOCS}${slug}/">${slug}</a>`).join(", ");
 
 /**
+ * A navigation list, indented to sit inside the fallback `<main>`.
+ *
+ * The demo's kit and feature navigation is React's, so until the bundle mounts
+ * — and permanently for anything that does not run JavaScript — every one of
+ * these 152 pages is reachable only from the one page that happens to link it.
+ * A crawler that cannot walk between them treats them as orphans and spends its
+ * budget accordingly. So the served markup carries the same grid of links the
+ * mounted page offers: each page names its kit's other features, the same
+ * feature in the other kits, and the way back up.
+ *
+ * @param {{ href: string, text: string, note?: string }[]} items
+ */
+const linkList = (items) =>
+  [
+    "        <ul>",
+    ...items.map(({ href, text, note }) => {
+      const trailer = note ? ` — ${escapeHtml(note)}` : "";
+      return `          <li><a href="${href}">${escapeHtml(text)}</a>${trailer}</li>`;
+    }),
+    "        </ul>",
+  ].join("\n");
+
+/** The built kits other than this one, in matrix order. */
+const otherKits = (adapter) =>
+  builtAdapters().filter((other) => other.key !== adapter.key);
+
+/** This kit's features other than this one, in demand order. */
+const siblingFeatures = (feature) =>
+  MATRIX_FEATURES.filter((other) => other.slug !== feature.slug);
+
+/**
  * One feature page's static HTML: the words a crawler reads, and the mount
  * point React takes over.
  */
@@ -266,6 +298,22 @@ ${note ? `        <p>${paragraph(note)}</p>\n` : ""}        <h2>The code</h2>
         <pre><code>${escapeHtml(fill(feature.snippet))}</code></pre>
         <h2>Install</h2>
         <pre><code>${escapeHtml(adapter.install)}</code></pre>
+        <h2>The same feature in the other kits</h2>
+${linkList(
+  otherKits(adapter).map((other) => ({
+    href: `../../${other.key}/${feature.slug}/`,
+    text: fillTemplate(feature.h1, other),
+    note: other.blurb,
+  }))
+)}
+        <h2>More ${escapeHtml(adapter.label)} features</h2>
+${linkList(
+  siblingFeatures(feature).map((sibling) => ({
+    href: `../${sibling.slug}/`,
+    text: fill(sibling.h1),
+    note: fill(sibling.card),
+  }))
+)}
         <p>
           Reference: ${docsList(feature.docs)}. More of this kit:
           <a href="../">AdaptTable for ${escapeHtml(adapter.label)}</a>, or
@@ -305,12 +353,22 @@ ${LANDING.intro.map((line) => `        <p>${paragraph(fill(line))}</p>`).join("\
         <h2>Install</h2>
         <pre><code>${escapeHtml(adapter.install)}</code></pre>
         <h2>Every feature, on its own page</h2>
-        <ul>
-${MATRIX_FEATURES.map(
-  (feature) =>
-    `          <li><a href="./${feature.slug}/">${escapeHtml(fill(feature.h1))}</a> — ${escapeHtml(fill(feature.card))}</li>`
-).join("\n")}
-        </ul>
+${linkList(
+  MATRIX_FEATURES.map((feature) => ({
+    href: `./${feature.slug}/`,
+    text: fill(feature.h1),
+    note: fill(feature.card),
+  }))
+)}
+        <h2>${escapeHtml(fill(LANDING.kitsTitle))}</h2>
+        <p>${paragraph(fill(LANDING.kitsLead))}</p>
+${linkList(
+  otherKits(adapter).map((other) => ({
+    href: `../${other.key}/`,
+    text: fillTemplate(LANDING.h1, other),
+    note: other.blurb,
+  }))
+)}
         <p>
           Reference: <a href="${DOCS}getting-started/">getting started</a>. Or
           open <a href="/adapttable/demo/">the live demo</a> and switch kits on

--- a/scripts/check-doc-surface.mjs
+++ b/scripts/check-doc-surface.mjs
@@ -29,6 +29,7 @@ import { fileURLToPath } from "node:url";
 import ts from "typescript";
 
 import { sidebarSlugs } from "../apps/docs/sidebar.mjs";
+import { TITLES } from "../apps/docs/sync-docs.mjs";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const DOCS_DIR = join(REPO_ROOT, "docs");
@@ -223,9 +224,49 @@ function printNavFailures({ orphans, dead }) {
   }
 }
 
+/**
+ * `docs/` and the page-title map compared both ways.
+ *
+ * A page missing from the `TITLES` map in `apps/docs/sync-docs.mjs` still
+ * builds: Starlight falls back to the filename, so the page ships as
+ * "filter-tree | AdaptTable" — a `<title>` that describes nothing, matches no
+ * query and is the one string search results and browser tabs show first.
+ * `stale` are entries whose markdown is gone; they mask the next real gap.
+ */
+function auditTitles() {
+  const named = new Set(Object.keys(TITLES));
+  return {
+    untitled: docPages.filter((name) => !named.has(name)),
+    stale: [...named]
+      .filter((name) => !docPages.includes(name))
+      .sort((a, b) => a.localeCompare(b)),
+  };
+}
+
+function printTitleFailures({ untitled, stale }) {
+  if (untitled.length > 0) {
+    console.error(
+      `\n${untitled.length} docs page(s) have no entry in the TITLES map of ` +
+        `apps/docs/sync-docs.mjs — each ships with its filename as its title:`
+    );
+    for (const name of untitled) {
+      console.error(`  - docs/${name} → "${name.replace(/\.md$/, "")}"`);
+    }
+  }
+  if (stale.length > 0) {
+    console.error(
+      `\n${stale.length} TITLES entr(ies) in apps/docs/sync-docs.mjs name a ` +
+        `page that does not exist:`
+    );
+    for (const name of stale) console.error(`  - ${name}`);
+  }
+}
+
 function main() {
   const audits = auditPackages();
   const nav = auditNav();
+  const titles = auditTitles();
+  const titleFailures = titles.untitled.length + titles.stale.length;
   const navFailures = nav.orphans.length + nav.dead.length;
   const exportTotal = audits.reduce((sum, a) => sum + a.names.length, 0);
   const undocumentedTotal = audits.reduce(
@@ -245,11 +286,21 @@ function main() {
       `Nav: ${docPages.length} pages, ${nav.orphans.length} missing from the ` +
         `sidebar, ${nav.dead.length} sidebar entr(ies) without a page.`
     );
+    console.log(
+      `Titles: ${titles.untitled.length} page(s) with no TITLES entry, ` +
+        `${titles.stale.length} entr(ies) without a page.`
+    );
     return;
   }
-  if (undocumentedTotal > 0 || missingRefTotal > 0 || navFailures > 0) {
+  if (
+    undocumentedTotal > 0 ||
+    missingRefTotal > 0 ||
+    navFailures > 0 ||
+    titleFailures > 0
+  ) {
     printFailures(audits, missingFromReference);
     printNavFailures(nav);
+    printTitleFailures(titles);
     if (undocumentedTotal > 0) {
       console.error(
         `\n${undocumentedTotal} undocumented export(s). Document each name in docs/ or stop exporting it.`
@@ -267,11 +318,17 @@ function main() {
           `apps/docs/sidebar.mjs, and every entry there needs its page.`
       );
     }
+    if (titleFailures > 0) {
+      console.error(
+        `${titleFailures} title mismatch(es). Every docs/*.md page needs a ` +
+          `TITLES entry in apps/docs/sync-docs.mjs, and every entry needs its page.`
+      );
+    }
     process.exit(1);
   }
   console.log(
     `doc-surface: all ${exportTotal} exports documented, ` +
-      `all ${docPages.length} pages in the sidebar.`
+      `all ${docPages.length} pages in the sidebar and titled.`
   );
 }
 


### PR DESCRIPTION
## What changed

- The generated demo pages serve the kit and feature navigation as real
  anchors. That grid only existed after React mounted, so the 152 pages were
  orphans to anything that does not run JavaScript.
- Five `docs:` entries in `apps/showcase/matrix.mjs` named slugs with no
  `docs/<slug>.md` behind them; every remaining slug in the matrix resolves.
- Six docs pages had no `TITLES` entry and shipped with their filename as the
  `<title>`. `check:docsurface` now compares `docs/` and the map both ways.

## Evidence

Internal demo anchors per page, counted on the built output:

| Page | Before | After |
| --- | --- | --- |
| kit landing (`/demo/mantine/`) | 19 | 26 |
| feature page (`/demo/mui/filtering/`) | 2 | 26 |

Across all 152 built pages: `kit landings n=8 min=26 max=26`, `feature pages
n=144 min=26 max=26`. All 3816 relative anchors resolve to a real matrix page,
and none points at a redirect stub.

The five slugs that 404'd, and their targets:

| Was | Now |
| --- | --- |
| `editing` | `cell-editing` |
| `performance` | dropped — `virtualization` is the page |
| `export-csv` | dropped — `export-pdf` is the page |
| `bulk-actions` | dropped — `selection` covers it |
| `grouping` | `row-grouping` |

Titles now served: `filter-tree` → "React table advanced filters — nested
AND/OR groups", plus `pivot`, `formulas`, `server-queries`, `tree-data` and
`migrate-from-v1`. All 46 map values are unique and under 60 characters.

The guard, with `filter-tree.md` removed from the map:

```
1 docs page(s) have no entry in the TITLES map of apps/docs/sync-docs.mjs — each ships with its filename as its title:
  - docs/filter-tree.md → "filter-tree"
1 title mismatch(es). Every docs/*.md page needs a TITLES entry in apps/docs/sync-docs.mjs, and every entry needs its page.
```

`node --test scripts/*.test.mjs` — 69 pass, 0 fail. `node
scripts/build-showcase-html.mjs` re-run is byte-identical.
`node scripts/check-doc-surface.mjs` — all 2212 exports documented, all 46
pages in the sidebar and titled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
