### PR TITLE
Link the demo hub to the kits, not the redirect stubs

### DIFF
--- a/apps/showcase/index.html
+++ b/apps/showcase/index.html
@@ -172,21 +172,40 @@
           </li>
           <li>Dark mode, and a responsive card layout on narrow screens.</li>
         </ul>
+        <h2>Every kit</h2>
+        <ul>
+          <li><a href="/adapttable/demo/mantine/">Mantine</a></li>
+          <li><a href="/adapttable/demo/mui/">Material UI</a></li>
+          <li><a href="/adapttable/demo/chakra/">Chakra UI</a></li>
+          <li><a href="/adapttable/demo/antd/">Ant Design</a></li>
+          <li><a href="/adapttable/demo/radix/">Radix Themes</a></li>
+          <li><a href="/adapttable/demo/base-ui/">Base UI</a></li>
+          <li><a href="/adapttable/demo/shadcn/">shadcn/ui</a></li>
+          <li><a href="/adapttable/demo/tailwind/">Tailwind, unstyled</a></li>
+        </ul>
         <h2>The other demos</h2>
         <ul>
           <li>
             <a href="/adapttable/demo/all-options/">Feature Lab</a>
           </li>
-          <li><a href="/adapttable/demo/columns/">Column management</a></li>
-          <li><a href="/adapttable/demo/editing/">Inline cell editing</a></li>
-          <li><a href="/adapttable/demo/grouping/">Row grouping</a></li>
           <li>
-            <a href="/adapttable/demo/export-pdf/">PDF export and print</a>
+            <a href="/adapttable/demo/mantine/columns/">Column management</a>
           </li>
-          <li><a href="/adapttable/demo/mobile/">Mobile cards</a></li>
-          <li><a href="/adapttable/demo/rtl/">Arabic and RTL</a></li>
           <li>
-            <a href="/adapttable/demo/scale/">50,000-row virtualization</a>
+            <a href="/adapttable/demo/mantine/editing/">Inline cell editing</a>
+          </li>
+          <li><a href="/adapttable/demo/mantine/grouping/">Row grouping</a></li>
+          <li>
+            <a href="/adapttable/demo/mantine/export/">PDF export and print</a>
+          </li>
+          <li>
+            <a href="/adapttable/demo/mantine/mobile-cards/">Mobile cards</a>
+          </li>
+          <li><a href="/adapttable/demo/mantine/rtl/">Arabic and RTL</a></li>
+          <li>
+            <a href="/adapttable/demo/mantine/scale/"
+              >50,000-row virtualization</a
+            >
           </li>
         </ul>
         <p>


### PR DESCRIPTION
The no-JS fallback on `/demo/` pointed its demo list at the seven meta-refresh
stubs and named no kit landing at all. A crawler reading raw HTML reached
`/demo/mantine/` only through a stub or down from a docs page, so the kit
landings sat 4–5 links from the site root and 114 feature pages sat at 4.

The hub now lists the eight kit landings and points each feature entry at the
page it serves. The stubs still resolve for anyone holding an old address;
they are no longer navigation.

## Link depth, measured on the built site

| | before | after |
| --- | --- | --- |
| kit landings (`/demo/mantine/`) | 4–5 | **2** |
| feature demos | 114 at 4, 14 at 5 | **3** |
| demo pages within 2 links of `/demo/` | — | **154 of 154** |

Nothing is deeper than three links from the root.

## Evidence

`pnpm format:check` clean, `pnpm test:scripts` 69/69, `e2e/nav-menu.spec.ts`
24/24. A no-JS crawl of `apps/showcase/dist` walks 154 demo pages from
`/demo/` and finds no link to a redirect stub; all eight kit landings are
linked from the hub.
